### PR TITLE
fix possible usage of already finished pthread_t

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -691,8 +691,11 @@ int transport_set_state(struct ba_transport *t, enum ba_transport_state state) {
 	switch (state) {
 	case TRANSPORT_IDLE:
 		if (created) {
-			pthread_cancel(t->thread);
-			ret = pthread_join(t->thread, NULL);
+			if( t-> release != NULL)
+			{
+				pthread_cancel(t->thread);
+				ret = pthread_join(t->thread, NULL);
+			}
 			t->thread = config.main_thread;
 		}
 		break;


### PR DESCRIPTION
transport_set_state() can use pthread_cancel() and pthread_join() on thread, that had been already finished. At least, with musl-libc this will cause segfault. 
Transport threads, in theirs turn, has release variable, which will be changed to NULL value when thread's cleanup routine will be executed, so this can be used as a sign, that thread had been already finished and no need to call pthread_join()