### PR TITLE
Allow external rfcomm

### DIFF
--- a/Makefile.am.include
+++ b/Makefile.am.include
@@ -1,0 +1,1 @@
+LOCAL_BLUEALSA_INCLUDES = -I$(top_srcdir)/src/shared

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,12 +2,11 @@
 # Copyright (c) 2016-2017 Arkadiusz Bokowy
 
 bin_PROGRAMS = bluealsa
-SUBDIRS = asound
+# put . so current directory is built before subdirectory for dependencies
+# TODO: wouldn't be necessary with non-recursive make or meson
+SUBDIRS = . asound
 
 bluealsa_SOURCES = \
-	shared/ffb.c \
-	shared/log.c \
-	shared/rt.c \
 	at.c \
 	bluealsa.c \
 	bluez.c \
@@ -19,6 +18,24 @@ bluealsa_SOURCES = \
 	transport.c \
 	utils.c \
 	main.c
+
+lib_headers = \
+	shared/ctl-client.h \
+	shared/ctl-proto.h \
+	shared/ffb.h \
+	shared/log.h \
+	shared/rt.h
+
+lib_sources = \
+	shared/ctl-client.c \
+	shared/ffb.c \
+	shared/log.c \
+	shared/rt.c
+
+lib_LTLIBRARIES = libbluealsa.la
+libbluealsa_la_SOURCES = $(lib_headers) $(lib_sources)
+libbluealsa_la_LDFLAGS = -version-info 0:0:0
+
 
 AM_CFLAGS = \
 	@BLUEZ_CFLAGS@ \
@@ -34,4 +51,9 @@ LDADD = \
 	@GIO2_LIBS@ \
 	@AAC_LIBS@ \
 	@APTX_LIBS@ \
-	@SBC_LIBS@
+	@SBC_LIBS@ \
+	libbluealsa.la
+
+# Install headers
+bluealsaincludedir = $(includedir)/bluealsa
+bluealsainclude_HEADERS = $(lib_headers)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,8 @@
 # BlueALSA - Makefile.am
 # Copyright (c) 2016-2017 Arkadiusz Bokowy
 
+include $(top_srcdir)/Makefile.am.include
+
 bin_PROGRAMS = bluealsa
 # put . so current directory is built before subdirectory for dependencies
 # TODO: wouldn't be necessary with non-recursive make or meson
@@ -20,22 +22,21 @@ bluealsa_SOURCES = \
 	main.c
 
 lib_headers = \
-	shared/ctl-client.h \
-	shared/ctl-proto.h \
-	shared/ffb.h \
-	shared/log.h \
-	shared/rt.h
+	shared/bluealsa/ctl-client.h \
+	shared/bluealsa/ctl-proto.h \
+	shared/bluealsa/ffb.h \
+	shared/bluealsa/log.h \
+	shared/bluealsa/rt.h
 
 lib_sources = \
-	shared/ctl-client.c \
-	shared/ffb.c \
-	shared/log.c \
-	shared/rt.c
+	shared/bluealsa/ctl-client.c \
+	shared/bluealsa/ffb.c \
+	shared/bluealsa/log.c \
+	shared/bluealsa/rt.c
 
 lib_LTLIBRARIES = libbluealsa.la
 libbluealsa_la_SOURCES = $(lib_headers) $(lib_sources)
 libbluealsa_la_LDFLAGS = -version-info 0:0:0
-
 
 AM_CFLAGS = \
 	@BLUEZ_CFLAGS@ \
@@ -43,7 +44,8 @@ AM_CFLAGS = \
 	@GIO2_CFLAGS@ \
 	@AAC_CFLAGS@ \
 	@APTX_CFLAGS@ \
-	@SBC_CFLAGS@
+	@SBC_CFLAGS@ \
+	$(LOCAL_BLUEALSA_INCLUDES)
 
 LDADD = \
 	@BLUEZ_LIBS@ \

--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -1,6 +1,8 @@
 # BlueALSA - Makefile.am
 # Copyright (c) 2016-2017 Arkadiusz Bokowy
 
+include $(top_srcdir)/Makefile.am.include
+
 EXTRA_DIST = 20-bluealsa.conf
 
 asound_module_ctl_LTLIBRARIES = libasound_module_ctl_bluealsa.la
@@ -17,10 +19,10 @@ asound_module_pcmdir = @ALSA_PLUGIN_DIR@
 asound_module_datadir = @ALSA_DATA_DIR@/alsa.conf.d
 
 AM_CFLAGS = \
-	-I$(top_srcdir)/src \
 	@ALSA_CFLAGS@ \
 	@BLUEZ_CFLAGS@ \
-	@GLIB2_CFLAGS@
+	@GLIB2_CFLAGS@ \
+	$(LOCAL_BLUEALSA_INCLUDES)
 
 AM_LDFLAGS = -module -avoid-version
 

--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -8,13 +8,8 @@ asound_module_pcm_LTLIBRARIES = libasound_module_pcm_bluealsa.la
 asound_module_data_DATA = 20-bluealsa.conf
 
 libasound_module_ctl_bluealsa_la_SOURCES = \
-	../shared/ctl-client.c \
-	../shared/log.c \
 	bluealsa-ctl.c
 libasound_module_pcm_bluealsa_la_SOURCES = \
-	../shared/ctl-client.c \
-	../shared/log.c \
-	../shared/rt.c \
 	bluealsa-pcm.c
 
 asound_module_ctldir = @ALSA_PLUGIN_DIR@
@@ -30,7 +25,9 @@ AM_CFLAGS = \
 AM_LDFLAGS = -module -avoid-version
 
 libasound_module_ctl_bluealsa_la_LIBADD = \
-	@ALSA_LIBS@
+	@ALSA_LIBS@ \
+	../libbluealsa.la
 libasound_module_pcm_bluealsa_la_LIBADD = \
 	@ALSA_LIBS@ \
-	@BLUEZ_LIBS@
+	@BLUEZ_LIBS@ \
+	../libbluealsa.la

--- a/src/asound/bluealsa-ctl.c
+++ b/src/asound/bluealsa-ctl.c
@@ -19,9 +19,9 @@
 #include <alsa/asoundlib.h>
 #include <alsa/control_external.h>
 
-#include "shared/ctl-client.h"
-#include "shared/ctl-proto.h"
-#include "shared/log.h"
+#include "bluealsa/ctl-client.h"
+#include "bluealsa/ctl-proto.h"
+#include "bluealsa/log.h"
 
 
 enum ctl_elem_type {

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -23,10 +23,10 @@
 #include <alsa/asoundlib.h>
 #include <alsa/pcm_external.h>
 
-#include "shared/ctl-client.h"
-#include "shared/ctl-proto.h"
-#include "shared/log.h"
-#include "shared/rt.h"
+#include "bluealsa/ctl-client.h"
+#include "bluealsa/ctl-proto.h"
+#include "bluealsa/log.h"
+#include "bluealsa/rt.h"
 
 
 struct bluealsa_pcm {

--- a/src/at.c
+++ b/src/at.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 /**

--- a/src/at.c
+++ b/src/at.c
@@ -51,6 +51,9 @@ char *at_build(char *buffer, enum bt_at_type type, const char *command,
 		else
 			sprintf(buffer, "\r\n%s\r\n", value);
 		break;
+	case AT_TYPE_CLIENT:
+		sprintf(buffer, "%s", command);
+		break;
 	case __AT_TYPE_MAX:
 		break;
 	}

--- a/src/at.h
+++ b/src/at.h
@@ -20,6 +20,9 @@ enum bt_at_type {
 	AT_TYPE_CMD_SET,
 	AT_TYPE_CMD_TEST,
 	AT_TYPE_RESP,
+	/* AT_TYPE_CLIENT added to give client full flexibility to
+	   write AT command with client required format */
+	AT_TYPE_CLIENT,
 	__AT_TYPE_MAX
 };
 

--- a/src/bluealsa.h
+++ b/src/bluealsa.h
@@ -26,7 +26,7 @@
 #include <gio/gio.h>
 
 #include "bluez.h"
-#include "shared/ctl-proto.h"
+#include "bluealsa/ctl-proto.h"
 
 /* Maximal number of clients connected to the controller. */
 #define BLUEALSA_MAX_CLIENTS 7

--- a/src/bluez.c
+++ b/src/bluez.c
@@ -23,7 +23,7 @@
 #include "bluez-iface.h"
 #include "transport.h"
 #include "utils.h"
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 /**

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -32,7 +32,7 @@
 #include "hfp.h"
 #include "transport.h"
 #include "utils.h"
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 /**

--- a/src/ctl.h
+++ b/src/ctl.h
@@ -11,7 +11,7 @@
 #ifndef BLUEALSA_CTL_H_
 #define BLUEALSA_CTL_H_
 
-#include "shared/ctl-proto.h"
+#include "bluealsa/ctl-proto.h"
 
 int bluealsa_ctl_thread_init(void);
 void bluealsa_ctl_free(void);

--- a/src/io.c
+++ b/src/io.c
@@ -39,9 +39,9 @@
 #include "bluealsa.h"
 #include "transport.h"
 #include "utils.h"
-#include "shared/ffb.h"
-#include "shared/log.h"
-#include "shared/rt.h"
+#include "bluealsa/ffb.h"
+#include "bluealsa/log.h"
+#include "bluealsa/rt.h"
 
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@
 #include "ctl.h"
 #include "transport.h"
 #include "utils.h"
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 static GMainLoop *loop = NULL;

--- a/src/rfcomm.c
+++ b/src/rfcomm.c
@@ -21,7 +21,7 @@
 #include "bluealsa.h"
 #include "ctl.h"
 #include "utils.h"
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 /**

--- a/src/shared/bluealsa/ctl-client.c
+++ b/src/shared/bluealsa/ctl-client.c
@@ -436,3 +436,19 @@ int bluealsa_drain_transport(int fd, const struct msg_transport *transport) {
 
 	return bluealsa_send_request(fd, &req);
 }
+
+int bluealsa_send_rfcomm_command(int fd, const char *device_address, const char *command_string)
+{
+	bdaddr_t addr;
+	str2ba (device_address, &addr);
+
+	struct request req = {
+		.command = COMMAND_RFCOMM_SEND,
+		.addr = addr,
+	};
+
+	/* snprintf guarantees terminating null character */
+	snprintf (req.rfcomm_command, sizeof(req.rfcomm_command), "%s", command_string);
+
+	return bluealsa_send_request(fd, &req);
+}

--- a/src/shared/bluealsa/ctl-client.c
+++ b/src/shared/bluealsa/ctl-client.c
@@ -8,7 +8,7 @@
  *
  */
 
-#include "shared/ctl-client.h"
+#include "bluealsa/ctl-client.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -19,7 +19,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 /**

--- a/src/shared/bluealsa/ctl-client.h
+++ b/src/shared/bluealsa/ctl-client.h
@@ -11,8 +11,12 @@
 #ifndef BLUEALSA_SHARED_CTLCLIENT_H_
 #define BLUEALSA_SHARED_CTLCLIENT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
-#include "shared/ctl-proto.h"
+#include "bluealsa/ctl-proto.h"
 
 int bluealsa_open(const char *interface);
 
@@ -33,5 +37,9 @@ int bluealsa_open_transport(int fd, const struct msg_transport *transport);
 int bluealsa_close_transport(int fd, const struct msg_transport *transport);
 int bluealsa_pause_transport(int fd, const struct msg_transport *transport, bool pause);
 int bluealsa_drain_transport(int fd, const struct msg_transport *transport);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/shared/bluealsa/ctl-client.h
+++ b/src/shared/bluealsa/ctl-client.h
@@ -38,6 +38,10 @@ int bluealsa_close_transport(int fd, const struct msg_transport *transport);
 int bluealsa_pause_transport(int fd, const struct msg_transport *transport, bool pause);
 int bluealsa_drain_transport(int fd, const struct msg_transport *transport);
 
+/* Send client formatted AT command to rfcomm transport by device address */
+/* Maximum length of command_string is 31 characters */
+int bluealsa_send_rfcomm_command(int fd, const char *device_address, const char *command_string);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shared/bluealsa/ctl-proto.h
+++ b/src/shared/bluealsa/ctl-proto.h
@@ -37,6 +37,7 @@ enum command {
 	COMMAND_PCM_PAUSE,
 	COMMAND_PCM_RESUME,
 	COMMAND_PCM_DRAIN,
+	COMMAND_RFCOMM_SEND,
 	__COMMAND_MAX
 };
 
@@ -93,6 +94,8 @@ struct __attribute__ ((packed)) request {
 	uint8_t ch2_muted:1;
 	uint8_t ch2_volume:7;
 
+	/* RFCOMM command string to send */
+	char rfcomm_command[32];
 };
 
 /**

--- a/src/shared/bluealsa/ctl-proto.h
+++ b/src/shared/bluealsa/ctl-proto.h
@@ -11,6 +11,10 @@
 #ifndef BLUEALSA_SHARED_CTLPROTO_H_
 #define BLUEALSA_SHARED_CTLPROTO_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -145,5 +149,9 @@ struct __attribute__ ((packed)) msg_transport {
 	uint16_t delay;
 
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/shared/bluealsa/ffb.c
+++ b/src/shared/bluealsa/ffb.c
@@ -8,7 +8,7 @@
  *
  */
 
-#include "shared/ffb.h"
+#include "bluealsa/ffb.h"
 
 #include <stdlib.h>
 

--- a/src/shared/bluealsa/ffb.h
+++ b/src/shared/bluealsa/ffb.h
@@ -11,6 +11,10 @@
 #ifndef BLUEALSA_SHARED_FFB_H_
 #define BLUEALSA_SHARED_FFB_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stddef.h>
 #include <string.h>
 
@@ -36,5 +40,9 @@ void ffb_free(struct ffb *ffb);
 		memmove((p)->data, (p)->data + (len), ffb_len_out(p) - (len)); \
 		(p)->tail -= len; \
 	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/shared/bluealsa/log.c
+++ b/src/shared/bluealsa/log.c
@@ -8,7 +8,7 @@
  *
  */
 
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 #include <pthread.h>
 #include <stdarg.h>
@@ -17,7 +17,7 @@
 #include <string.h>
 #include <syslog.h>
 
-#include "shared/rt.h"
+#include "bluealsa/rt.h"
 
 
 /* internal logging identifier */

--- a/src/shared/bluealsa/log.h
+++ b/src/shared/bluealsa/log.h
@@ -11,6 +11,10 @@
 #ifndef BLUEALSA_SHARED_LOG_H_
 #define BLUEALSA_SHARED_LOG_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -40,6 +44,10 @@ void _debug(const char *format, ...) __attribute__ ((format(printf, 1, 2)));
 void hexdump(const char *label, const void *mem, size_t len);
 #else
 # define hexdump(A, M, L) do {} while (0)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/src/shared/bluealsa/rt.c
+++ b/src/shared/bluealsa/rt.c
@@ -8,7 +8,7 @@
  *
  */
 
-#include "shared/rt.h"
+#include "bluealsa/rt.h"
 
 #include <stdlib.h>
 

--- a/src/shared/bluealsa/rt.h
+++ b/src/shared/bluealsa/rt.h
@@ -11,6 +11,10 @@
 #ifndef BLUEALSA_SHARED_RT_H_
 #define BLUEALSA_SHARED_RT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <time.h>
 
@@ -69,5 +73,9 @@ int difftimespec(
 		const struct timespec *ts1,
 		const struct timespec *ts2,
 		struct timespec *ts);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/transport.c
+++ b/src/transport.c
@@ -32,7 +32,7 @@
 #include "io.h"
 #include "rfcomm.h"
 #include "utils.h"
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 static int io_thread_create(struct ba_transport *t) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -310,6 +310,9 @@ struct ba_transport *transport_new_rfcomm(
 					dbus_owner, dbus_path_sco, profile, HFP_CODEC_UNDEFINED)) == NULL)
 		goto fail;
 
+	t->rfcomm.commands = g_ptr_array_new_with_free_func(free);
+	pthread_mutex_init(&t->rfcomm.commands_mutex, NULL);
+
 	t->rfcomm.sco = t_sco;
 	t_sco->sco.rfcomm = t;
 
@@ -902,6 +905,10 @@ int transport_release_bt_rfcomm(struct ba_transport *t) {
 	shutdown(t->bt_fd, SHUT_RDWR);
 	close(t->bt_fd);
 	t->bt_fd = -1;
+
+	debug("Releasing rfcomm commands list");
+	g_ptr_array_free(t->rfcomm.commands, TRUE);
+	pthread_mutex_destroy(&t->rfcomm.commands_mutex);
 
 	/* BlueZ does not trigger profile disconnection signal when the Bluetooth
 	 * link has been lost (e.g. device power down). However, it is required to

--- a/src/transport.h
+++ b/src/transport.h
@@ -159,6 +159,9 @@ struct ba_transport {
 			/* received AG indicator values */
 			unsigned char hfp_inds[__HFP_IND_MAX];
 
+			pthread_mutex_t commands_mutex;
+			GPtrArray *commands;
+
 		} rfcomm;
 
 		struct {

--- a/src/utils.c
+++ b/src/utils.c
@@ -20,7 +20,7 @@
 
 #include "a2dp-codecs.h"
 #include "bluez.h"
-#include "shared/log.h"
+#include "bluealsa/log.h"
 
 
 /**

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,8 @@
 # BlueALSA - Makefile.am
 # Copyright (c) 2016-2017 Arkadiusz Bokowy
 
+include $(top_srcdir)/Makefile.am.include
+
 TESTS = \
 	test-at \
 	test-io \
@@ -18,14 +20,14 @@ check_PROGRAMS = \
 	test-utils
 
 AM_CFLAGS = \
-	-I$(top_srcdir)/src \
 	@ALSA_CFLAGS@ \
 	@BLUEZ_CFLAGS@ \
 	@GLIB2_CFLAGS@ \
 	@GIO2_CFLAGS@ \
 	@AAC_CFLAGS@ \
 	@APTX_CFLAGS@ \
-	@SBC_CFLAGS@
+	@SBC_CFLAGS@ \
+	$(LOCAL_BLUEALSA_INCLUDES)
 
 LDADD = \
 	@ALSA_LIBS@ \
@@ -34,4 +36,5 @@ LDADD = \
 	@GIO2_LIBS@ \
 	@AAC_LIBS@ \
 	@APTX_LIBS@ \
-	@SBC_LIBS@
+	@SBC_LIBS@ \
+	../src/libbluealsa.la

--- a/test/test-io.c
+++ b/test/test-io.c
@@ -19,8 +19,6 @@
 #include "../src/rfcomm.c"
 #include "../src/transport.c"
 #include "../src/utils.c"
-#include "../src/shared/ffb.c"
-#include "../src/shared/rt.c"
 
 static const a2dp_sbc_t config_sbc_44100_joint_stereo = {
 	.frequency = SBC_SAMPLING_FREQ_44100,

--- a/test/test-pcm.c
+++ b/test/test-pcm.c
@@ -16,8 +16,7 @@
 #include <alsa/asoundlib.h>
 #include "inc/sine.inc"
 #include "inc/test.inc"
-#include "../src/shared/ffb.c"
-#include "../src/shared/log.h"
+#include "bluealsa/log.h"
 
 
 static char *bin_path = NULL;

--- a/test/test-server.c
+++ b/test/test-server.c
@@ -35,8 +35,6 @@
 #include "../src/transport.c"
 #undef transport_acquire_bt_a2dp
 #include "../src/utils.c"
-#include "../src/shared/ffb.c"
-#include "../src/shared/rt.c"
 
 static const a2dp_sbc_t cconfig = {
 	.frequency = SBC_SAMPLING_FREQ_44100,

--- a/test/test-utils.c
+++ b/test/test-utils.c
@@ -10,8 +10,7 @@
 
 #include "inc/test.inc"
 #include "../src/utils.c"
-#include "../src/shared/ffb.c"
-#include "../src/shared/rt.c"
+#include "bluealsa/ffb.h"
 
 int test_dbus_profile_object_path(void) {
 

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,6 +1,8 @@
 # BlueALSA - Makefile.am
 # Copyright (c) 2016-2017 Arkadiusz Bokowy
 
+include $(top_srcdir)/Makefile.am.include
+
 bin_PROGRAMS =
 
 if ENABLE_APLAY
@@ -8,10 +10,10 @@ bin_PROGRAMS += bluealsa-aplay
 bluealsa_aplay_SOURCES = \
 	aplay.c
 bluealsa_aplay_CFLAGS = \
-	-I$(top_srcdir)/src \
 	@ALSA_CFLAGS@ \
 	@BLUEZ_CFLAGS@ \
-	@GIO2_CFLAGS@
+	@GIO2_CFLAGS@ \
+	$(LOCAL_BLUEALSA_INCLUDES)
 bluealsa_aplay_LDADD = \
 	@ALSA_LIBS@ \
 	@BLUEZ_LIBS@ \

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -6,8 +6,6 @@ bin_PROGRAMS =
 if ENABLE_APLAY
 bin_PROGRAMS += bluealsa-aplay
 bluealsa_aplay_SOURCES = \
-	../src/shared/ctl-client.c \
-	../src/shared/log.c \
 	aplay.c
 bluealsa_aplay_CFLAGS = \
 	-I$(top_srcdir)/src \
@@ -17,7 +15,8 @@ bluealsa_aplay_CFLAGS = \
 bluealsa_aplay_LDADD = \
 	@ALSA_LIBS@ \
 	@BLUEZ_LIBS@ \
-	@GIO2_LIBS@
+	@GIO2_LIBS@ \
+	../src/libbluealsa.la
 endif
 
 if ENABLE_HCITOP

--- a/utils/aplay.c
+++ b/utils/aplay.c
@@ -25,8 +25,8 @@
 #include <alsa/asoundlib.h>
 #include <gio/gio.h>
 
-#include "shared/ctl-client.h"
-#include "shared/log.h"
+#include "bluealsa/ctl-client.h"
+#include "bluealsa/log.h"
 
 /* Casting wrapper for the brevity's sake. */
 #define CANCEL_ROUTINE(f) ((void (*)(void *))(f))


### PR DESCRIPTION
NOTE: this pull request depends on pull request #95 , but I wanted to publish this to start getting feedback.  To review, only the latest commit should be evaluated, and not the commits from #95.

This allows sending arbitrary rfcomm commands to the device.  I think a corresponding (although unimplemented) feature would be able to subscribe to all rfcomm commands from a device.

One advantage of doing it this way (opposed to sharing a "raw" file descriptor) was:

* It's pretty simple
* it coincides with the daemon's own rfcomm communication

Thoughts/feedback is welcome.

A prior discussion happened in issue #85 .