### PR TITLE
Fix segmentation fault

### DIFF
--- a/utils/aplay.c
+++ b/utils/aplay.c
@@ -684,6 +684,7 @@ init:
 				worker->active = false;
 				worker->pcm_fd = -1;
 				worker->ba_fd = -1;
+				worker->pcm = NULL;
 
 				debug("Creating PCM worker %s", worker->addr);
 


### PR DESCRIPTION
Initialize `pcm` with NULL as this lines checks for `pcm`: https://github.com/Arkq/bluez-alsa/blob/master/utils/aplay.c#L384. Otherwise, this might result in a segmentation fault in the alsa library.