### PR TITLE
Do not fail if recv returns less bytes than requested

### DIFF
--- a/utils/aplay.c
+++ b/utils/aplay.c
@@ -617,6 +617,8 @@ usage:
 			continue;
 		if (ret != sizeof(event)) {
 			error("Couldn't read event: %s", strerror(ret == -1 ? errno : EBADMSG));
+			if (ret > 0)
+				continue;
 			goto fail;
 		}
 


### PR DESCRIPTION
`recv()` might return less bytes than requested, e.g. because it was interrupted by a system call. Therefore, do not fail and exit the main loop.