### PR TITLE
Make transport protocol sampling rate a 32-bit field

### DIFF
--- a/src/shared/ctl-proto.h
+++ b/src/shared/ctl-proto.h
@@ -152,7 +152,7 @@ struct __attribute__ ((packed)) ba_msg_transport {
 	/* number of audio channels */
 	uint8_t channels;
 	/* used sampling frequency */
-	uint16_t sampling;
+	uint32_t sampling;
 
 	/* Levels for channel 1 (left) and 2 (right). These fields are also
 	 * used for SCO. In such a case channel 1 and 2 is responsible for


### PR DESCRIPTION
Otherwise playback fails with sampling rate of 96 kHz, because due to the integer overflow, ALSA thinks the actual sampling rate is around 30 kHz.

I've verified that this fixes the playback issue at least with LDAC (#104).

Thank you for the great work with `bluez-alsa`! I'm so happy being finally able to get rid of my headphone wires. :smile: 