### PR TITLE
Move config files to /etc/alsa/conf.d

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ PKG_CHECK_MODULES([GIO2], [gio-unix-2.0])
 PKG_CHECK_MODULES([SBC], [sbc >= 1.2])
 
 AM_CONDITIONAL([ALSA_1_1_2], [$PKG_CONFIG --atleast-version=1.1.2 alsa])
+AM_CONDITIONAL([ALSA_1_1_7], [$PKG_CONFIG --atleast-version=1.1.7 alsa])
 
 AC_ARG_ENABLE([aac],
 	[AS_HELP_STRING([--enable-aac], [enable AAC support])])
@@ -115,7 +116,10 @@ AC_ARG_WITH([alsaplugindir],
 	[alsaplugindir="$withval"], [alsaplugindir=$($PKG_CONFIG --variable=libdir alsa)/alsa-lib])
 AC_ARG_WITH([alsaconfdir],
 	AS_HELP_STRING([--with-alsaconfdir=dir], [directory containing ALSA add-on configuration files]),
-	[alsaconfdir="$withval"], [alsaconfdir="$sysconfdir/alsa"])
+	[alsaconfdir="$withval"],
+	[AM_COND_IF([ALSA_1_1_7],
+		[alsaconfdir="$sysconfdir/alsa/conf.d"],
+		[alsaconfdir="$sysdatadir/alsa/alsa.conf.d"])])
 
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
 test "x$exec_prefix" = xNONE && exec_prefix=$prefix

--- a/configure.ac
+++ b/configure.ac
@@ -113,25 +113,25 @@ AM_CONDITIONAL([ENABLE_PCM_TEST], [test "x$enable_pcm_test" = "xyes"])
 AC_ARG_WITH([alsaplugindir],
 	AS_HELP_STRING([--with-alsaplugindir=dir], [path where ALSA plugin files are stored]),
 	[alsaplugindir="$withval"], [alsaplugindir=$($PKG_CONFIG --variable=libdir alsa)/alsa-lib])
-AC_ARG_WITH([alsadatadir],
-	AS_HELP_STRING([--with-alsadatadir=dir], [directory containing ALSA data files]),
-	[alsadatadir="$withval"], [alsadatadir="$datadir/alsa"])
+AC_ARG_WITH([alsaconfdir],
+	AS_HELP_STRING([--with-alsaconfdir=dir], [directory containing ALSA add-on configuration files]),
+	[alsaconfdir="$withval"], [alsaconfdir="$sysconfdir/alsa"])
 
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
 test "x$exec_prefix" = xNONE && exec_prefix=$prefix
 
 # TODO: Get rid of "ev(a|i)l" statements.
 # TIP: Wizard-level Autotconf coder is needed.
-eval alsadatadir="$alsadatadir"
-eval alsadatadir="$alsadatadir"
+eval alsaconfdir="$alsaconfdir"
+eval alsaconfdir="$alsaconfdir"
 eval alsaplugindir="$alsaplugindir"
 eval alsaplugindir="$alsaplugindir"
 
-AC_DEFINE_UNQUOTED([ALSA_DATA_DIR], "$alsadatadir", [Directory containing ALSA data files.])
+AC_DEFINE_UNQUOTED([ALSA_CONF_DIR], "$alsaconfdir", [Directory containing ALSA add-on configuration files.])
 AC_DEFINE_UNQUOTED([ALSA_PLUGIN_DIR], "$alsaplugindir", [Directory containing ALSA add-on modules.])
 AC_DEFINE_UNQUOTED([RUN_STATE_DIR], "$runstatedir", [Path where run statuses are stored.])
 
-AC_SUBST([ALSA_DATA_DIR], [$alsadatadir])
+AC_SUBST([ALSA_CONF_DIR], [$alsaconfdir])
 AC_SUBST([ALSA_PLUGIN_DIR], [$alsaplugindir])
 AC_SUBST([RUN_STATE_DIR], [$runstatedir])
 

--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -19,7 +19,7 @@ libasound_module_pcm_bluealsa_la_SOURCES = \
 
 asound_module_ctldir = @ALSA_PLUGIN_DIR@
 asound_module_pcmdir = @ALSA_PLUGIN_DIR@
-asound_module_datadir = @ALSA_DATA_DIR@/alsa.conf.d
+asound_module_datadir = @ALSA_CONF_DIR@/conf.d
 
 AM_CFLAGS = \
 	-I$(top_srcdir)/src \

--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -5,7 +5,7 @@ EXTRA_DIST = 20-bluealsa.conf
 
 asound_module_ctl_LTLIBRARIES = libasound_module_ctl_bluealsa.la
 asound_module_pcm_LTLIBRARIES = libasound_module_pcm_bluealsa.la
-asound_module_data_DATA = 20-bluealsa.conf
+asound_module_sysconf_DATA = 20-bluealsa.conf
 
 libasound_module_ctl_bluealsa_la_SOURCES = \
 	../shared/ctl-client.c \
@@ -19,7 +19,7 @@ libasound_module_pcm_bluealsa_la_SOURCES = \
 
 asound_module_ctldir = @ALSA_PLUGIN_DIR@
 asound_module_pcmdir = @ALSA_PLUGIN_DIR@
-asound_module_datadir = @ALSA_CONF_DIR@/conf.d
+asound_module_sysconfdir = @ALSA_CONF_DIR@
 
 AM_CFLAGS = \
 	-I$(top_srcdir)/src \


### PR DESCRIPTION
With the release of alsa-lib v1.1.7, the location for add-on configs
has changed to /etc/alsa/conf.d/.

See:
http://git.alsa-project.org/?p=alsa-lib.git;a=commit;h=93e03bdc2a3dcd5d12516f5de78e14d88a32ff2c

Also related to #155.