### PR TITLE
Prevent crashes when logging to syslog

### DIFF
--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -50,8 +50,12 @@ static void vlog(int priority, const char *format, va_list ap) {
 	 * has to be temporally disabled. */
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &oldstate);
 
-	if (_syslog)
-		vsyslog(priority, format, ap);
+	if (_syslog) {
+		va_list ap_syslog;
+		va_copy(ap_syslog, ap);
+		vsyslog(priority, format, ap_syslog);
+		va_end(ap_syslog);
+	}
 
 	flockfile(stderr);
 


### PR DESCRIPTION
As explained by the man page for `va_arg()`:

> If `ap` is passed to a function that uses `va_arg(ap,type)`, then the value of `ap` is undefined after the return of that function.

Meanwhile, when logging to syslog is enabled, `vlog()` reuses the same `va_list` variable for both the `vsyslog()` call and the subsequent `vfprintf()` call.  This causes crashes, try:

```sh
# touch /var/run/bluealsa/hci0
# bluealsa -S
```

This PR fixes the issue by passing `vsyslog()` a copy of the `va_list` supplied to `vlog()`.
