### PR TITLE
Explicitly include stdint.h for musl compatibility

### DIFF
--- a/test/inc/sine.inc
+++ b/test/inc/sine.inc
@@ -13,6 +13,7 @@
 #include <limits.h>
 #include <math.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 /**
  * Generate sine PCM signal.


### PR DESCRIPTION
I just noticed the build fails on Alpine linux, probably due to musl-libc being used. Including stdint.h fixes this.