### PR TITLE
bluealsa-pcm: bump the trigger after pcm prepare

### DIFF
--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -353,6 +353,12 @@ static int bluealsa_prepare(snd_pcm_ioplug_t *io) {
 	pcm->io_ptr = 0;
 
 	debug("Prepared: %d", pcm->fd);
+
+	/* When the sound application calls poll just after snd_pcm_prepare,
+	 * it would block forever unless the internal trigger is bumped
+	 * */
+	eventfd_write(pcm->event_fd, 1);
+
 	return 0;
 }
 


### PR DESCRIPTION
When a sound application recovers from a EPIPE by calling
snd_pcm_prepare, and goes immediately after to a call to poll,
it would be stuck forever unless the internal event trigger
is bumped.

Signed-off-by: Thierry Bultel <thierry.bultel@iot.bzh>