### PR TITLE
make bluealsa_poll_revents() behave like hardware devices

### DIFF
--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -494,31 +494,25 @@ static int bluealsa_poll_revents(snd_pcm_ioplug_t *io, struct pollfd *pfd,
 		if (event & 0xDEAD0000)
 			goto fail;
 
-		/* Return POLLERR if PCM is suspended or xrun has occurred. */
-		if (io->state == SND_PCM_STATE_SUSPENDED ||
-				io->state == SND_PCM_STATE_XRUN) {
-			*revents = POLLERR;
+		/* ALSA expects that the event will match stream direction, e.g.
+		 * playback will not start if the event is for reading. */
+		*revents = io->stream == SND_PCM_STREAM_CAPTURE ? POLLIN : POLLOUT;
+
+		/* Include POLLERR if PCM is not running or draining. */
+		if (io->state != SND_PCM_STATE_RUNNING &&
+				io->state != SND_PCM_STATE_DRAINING) {
+			*revents |= POLLERR;
+			/* a playback application may write less than start_threshold frames on
+			 * its first write and then wait in poll() forever because the event_fd
+			 * never gets written to again.
+			 * To prevent this possibility, we bump the internal trigger. */
+			if (snd_pcm_stream(io->pcm) == SND_PCM_STREAM_PLAYBACK)
+				eventfd_write(pcm->event_fd, 1);
 			return 0;
 		}
 
 		/* If the event was triggered prematurely, wait for another one. */
 		if (!snd_pcm_avail_update(io->pcm))
-			return *revents = 0;
-
-		/* ALSA expects that the event will match stream direction, e.g.
-		 * playback will not start if the event is for reading. */
-		*revents = io->stream == SND_PCM_STREAM_CAPTURE ? POLLIN : POLLOUT;
-
-		/* If the IO thread is not yet started, or is paused after an xrun,
-		 * a playback application may write less than start_threshold frames on
-		 * its first write and then wait in poll() forever because the event_fd
-		 * never gets written to again.
-		 * To prevent this possibility, we bump the internal trigger. */
-		if (snd_pcm_stream(io->pcm) == SND_PCM_STREAM_PLAYBACK && (
-					!pcm->io_started || (io->state != SND_PCM_STATE_RUNNING &&
-						io->state != SND_PCM_STATE_DRAINING)))
-			eventfd_write(pcm->event_fd, 1);
-
 	}
 	else if (pfd[1].revents & POLLHUP)
 		/* server closed connection */


### PR DESCRIPTION
Modify bluealsa_poll_revents() so that behaviour is closer to that of the hw plugin. After poll() has been called by the application while the pcm is not in a running state, set the POLLERR flag and reload the event trigger in the cases where the hw plugin does.