### PR TITLE
Double free

### DIFF
--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -725,7 +725,7 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 
 	if ((ret = bluealsa_set_hw_constraint(pcm)) < 0) {
 		snd_pcm_ioplug_delete(&pcm->io);
-		goto fail;
+		return ret;
 	}
 
 	*pcmp = pcm->io.pcm;


### PR DESCRIPTION
Fixes a double free in SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa). This same error was in the pulseaudio plugin and was fixed there in this commit [https://git.alsa-project.org/?p=alsa-plugins.git;a=commit;h=c96e167bcedfb91526780f7da86fc0872017119d](https://git.alsa-project.org/?p=alsa-plugins.git;a=commit;h=c96e167bcedfb91526780f7da86fc0872017119d)