### PR TITLE
configure.ac: Fix pkg-config checks for libldac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,8 +81,8 @@ AC_ARG_ENABLE([ldac],
 	[AS_HELP_STRING([--enable-ldac], [enable LDAC support])])
 AM_CONDITIONAL([ENABLE_LDAC], [test "x$enable_ldac" = "xyes"])
 AM_COND_IF([ENABLE_LDAC], [
-	PKG_CHECK_MODULES([LDAC], [libldacBT >= 2.0.0])
-	PKG_CHECK_MODULES([LDAC_ABR], [libldacBT_abr >= 2.0.0])
+	PKG_CHECK_MODULES([LDAC], [ldacBT-enc >= 2.0.0])
+	PKG_CHECK_MODULES([LDAC_ABR], [ldacBT-abr >= 2.0.0])
 	AC_DEFINE([ENABLE_LDAC], [1], [Define to 1 if LDAC is enabled.])
 ])
 


### PR DESCRIPTION
on my Gentoo machine, an unpatched libldac-2.0.2 provides the following pkgconfig files:

```
# qlist -Ce libldac | grep "\.pc$"
/usr/lib64/pkgconfig/ldacBT-enc.pc
/usr/lib64/pkgconfig/ldacBT-abr.pc
```

so with `--enable-ldac` configure fails with the following error message:
```
checking for libldacBT >= 2.0.0... no
configure: error: Package requirements (libldacBT >= 2.0.0) were not met:

No package 'libldacBT' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.
Alternatively, you may set the environment variables LDAC_CFLAGS
and LDAC_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```

This patch fixes the issue.