### PR TITLE
Fix typo in Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@
 bin_PROGRAMS = bluealsa
 SUBDIRS = asound
 
-dbusconfdir = @DBUS_CONFDIR@
+dbusconfdir = @DBUS_CONF_DIR@
 dist_dbusconf_DATA = bluealsa.conf
 
 bluealsa_SOURCES = \


### PR DESCRIPTION
Replace `DBUS_CONFDIR` by `DBUS_CONF_DIR`.