### PR TITLE
Rewind LATM buffer on aacDecode error

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -764,9 +764,8 @@ void *io_thread_a2dp_sink_aac(void *arg) {
 			io_thread_scale_pcm(t, pcm.data, samples, channels);
 			if (io_thread_write_pcm(&t->a2dp.pcm, pcm.data, samples) == -1)
 				error("FIFO write error: %s", strerror(errno));
-			ffb_rewind(&latm);
 		}
-
+		ffb_rewind(&latm);
 	}
 
 fail:


### PR DESCRIPTION
If latm buffer is not rewinded on unsuccessful decoding, same bt frame data will be retried for decoding. If the frame is unable to decode latm buffer will be allocated more memory to store new bt frames and will eventually cause OOM. Since retry on the same frame is not going to cause aac decode to success, it is best to just drop the frame and carry on.

Fixes #215