### PR TITLE
utils/aplay.c: use correct type for pfd count

### DIFF
--- a/utils/aplay.c
+++ b/utils/aplay.c
@@ -782,7 +782,7 @@ usage:
 	while (main_loop_on) {
 
 		struct pollfd pfds[10];
-		size_t pfds_len = ARRAYSIZE(pfds);
+		nfds_t pfds_len = ARRAYSIZE(pfds);
 
 		if (!bluealsa_dbus_connection_poll_fds(&dbus_ctx, pfds, &pfds_len)) {
 			error("Couldn't get D-Bus connection file descriptors");


### PR DESCRIPTION
original code assumed sizeof(nfds_t) == sizeof(size_t); that is not true on all architectures. This commit corrects that and so removes the compiler warning on such architectures.