### PR TITLE
src/ba-transport.c: use correct mtu for SCO links

### DIFF
--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -815,26 +815,19 @@ static int transport_acquire_bt_sco(struct ba_transport *t) {
 	if (t->bt_fd != -1)
 		return t->bt_fd;
 
-	if (hci_devinfo(t->d->a->hci_dev_id, &di) == -1) {
-		error("Couldn't get HCI device info: %s", strerror(errno));
+	if ((t->bt_fd = hci_open_sco(t->d->a->hci_dev_id, &t->d->addr, t->type.codec != HFP_CODEC_CVSD)) == -1) {
+		error("Couldn't open SCO link: %s", strerror(errno));
 		return -1;
 	}
 
-	if ((t->bt_fd = hci_open_sco(di.dev_id, &t->d->addr, t->type.codec != HFP_CODEC_CVSD)) == -1) {
-		error("Couldn't open SCO link: %s", strerror(errno));
+	if (hci_devinfo(t->d->a->hci_dev_id, &di) == -1) {
+		error("Couldn't get HCI device info: %s", strerror(errno));
+		transport_release_bt_sco(t);
 		return -1;
 	}
 
 	t->mtu_read = di.sco_mtu;
 	t->mtu_write = di.sco_mtu;
-
-	/* XXX: It seems, that the MTU values returned by the HCI interface
-	 *      are incorrect (or our interpretation of them is incorrect). */
-	t->mtu_read = 48;
-	t->mtu_write = 48;
-
-	if (t->type.codec == HFP_CODEC_MSBC)
-		t->mtu_read = t->mtu_write = 24;
 
 	debug("New SCO link: %d (MTU: R:%zu W:%zu)", t->bt_fd, t->mtu_read, t->mtu_write);
 


### PR DESCRIPTION
For SCO audio links, we *must* send data in chunks of the link mtu size to ensure correct timing. To use a constant value of 48 or 24 bytes is just wrong.

Obtain the link config *after* successful connection, because before then the mtu has not been negotiated with the remote device