### PR TITLE
Start stop issues

### DIFF
--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -279,6 +279,15 @@ static int bluealsa_stop(snd_pcm_ioplug_t *io) {
 	struct bluealsa_pcm *pcm = io->private_data;
 	debug2("Stopping");
 
+       /* It is possible for this function to be called from an invalid state,
+        * so we need to make it a no-op in those cases. */
+       switch (io->state) {
+               case SND_PCM_STATE_OPEN:
+               case SND_PCM_STATE_SETUP:
+               case SND_PCM_STATE_DISCONNECTED:
+                       return 0;
+       }
+
 	if (pcm->io_started) {
 		pcm->io_started = false;
 		pthread_cancel(pcm->io_thread);


### PR DESCRIPTION
Looking into problems with sox play and mpg123, I've found an issue caused by the way these applications close and then immediately re-open a bluealsa device, and also with mpg123 in particular that an application can cause the client to call bluealsa_stop() twice.

This PR attempts to fix these issues. See comments against each of the two commits for further details.