### PR TITLE
Allow to set ALSA PCM format

### DIFF
--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -546,6 +546,10 @@ unsigned int ba_transport_get_sampling(const struct ba_transport *t) {
 	return 0;
 }
 
+uint16_t ba_transport_get_format(const struct ba_transport *t) {
+	return g_dbus_transport_get_pcm_format(t->type);
+}
+
 uint16_t ba_transport_get_delay(const struct ba_transport *t) {
 	if (t->type.profile & BA_TRANSPORT_PROFILE_MASK_A2DP)
 		return t->delay + t->a2dp.delay;

--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -888,7 +888,7 @@ static int transport_release_bt_sco(struct ba_transport *t) {
 	return 0;
 }
 
-int ba_transport_release_pcm(struct ba_pcm *pcm) {
+int ba_transport_release_pcm(struct ba_transport_pcm *pcm) {
 
 	if (pcm->fd == -1)
 		return 0;

--- a/src/ba-transport.h
+++ b/src/ba-transport.h
@@ -67,7 +67,7 @@ enum ba_transport_signal {
 	TRANSPORT_SET_VOLUME,
 };
 
-struct ba_pcm {
+struct ba_transport_pcm {
 	/* FIFO file descriptor */
 	int fd;
 	/* associated client */
@@ -130,7 +130,7 @@ struct ba_transport {
 			/* delay reported by the AVDTP */
 			uint16_t delay;
 
-			struct ba_pcm pcm;
+			struct ba_transport_pcm pcm;
 
 			/* selected audio codec configuration */
 			uint8_t *cconfig;
@@ -182,8 +182,8 @@ struct ba_transport {
 			/* Speaker and microphone signals should to be exposed as
 			 * a separate PCM devices. Hence, there is a requirement
 			 * for separate configurations. */
-			struct ba_pcm spk_pcm;
-			struct ba_pcm mic_pcm;
+			struct ba_transport_pcm spk_pcm;
+			struct ba_transport_pcm mic_pcm;
 
 			/* playback synchronization */
 			pthread_mutex_t spk_drained_mtx;
@@ -251,7 +251,7 @@ int ba_transport_set_volume_packed(struct ba_transport *t, uint16_t value);
 int ba_transport_set_state(struct ba_transport *t, enum ba_transport_state state);
 
 int ba_transport_drain_pcm(struct ba_transport *t);
-int ba_transport_release_pcm(struct ba_pcm *pcm);
+int ba_transport_release_pcm(struct ba_transport_pcm *pcm);
 
 void ba_transport_pthread_cancel(pthread_t thread);
 void ba_transport_pthread_cleanup(struct ba_transport *t);

--- a/src/ba-transport.h
+++ b/src/ba-transport.h
@@ -243,6 +243,7 @@ enum ba_transport_signal ba_transport_recv_signal(struct ba_transport *t);
 
 unsigned int ba_transport_get_channels(const struct ba_transport *t);
 unsigned int ba_transport_get_sampling(const struct ba_transport *t);
+uint16_t ba_transport_get_format(const struct ba_transport *t);
 uint16_t ba_transport_get_delay(const struct ba_transport *t);
 
 uint16_t ba_transport_get_volume_packed(const struct ba_transport *t);

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -57,6 +57,10 @@ static GVariant *ba_variant_new_sampling(const struct ba_transport *t) {
 	return g_variant_new_uint32(ba_transport_get_sampling(t));
 }
 
+static GVariant *ba_variant_new_format(const struct ba_transport *t) {
+	return g_variant_new_uint16(ba_transport_get_format(t));
+}
+
 static GVariant *ba_variant_new_codec(const struct ba_transport *t) {
 	return g_variant_new_uint16(t->type.codec);
 }
@@ -108,6 +112,7 @@ static void bluealsa_manager_get_pcms(GDBusMethodInvocation *inv, void *userdata
 				g_variant_builder_add(&props, "{sv}", "Modes", ba_variant_new_pcm_modes(t));
 				g_variant_builder_add(&props, "{sv}", "Channels", ba_variant_new_channels(t));
 				g_variant_builder_add(&props, "{sv}", "Sampling", ba_variant_new_sampling(t));
+				g_variant_builder_add(&props, "{sv}", "Format", ba_variant_new_format(t));
 				g_variant_builder_add(&props, "{sv}", "Codec", ba_variant_new_codec(t));
 				g_variant_builder_add(&props, "{sv}", "Delay", ba_variant_new_delay(t));
 				g_variant_builder_add(&props, "{sv}", "Volume", ba_variant_new_volume(t));
@@ -394,6 +399,8 @@ static GVariant *bluealsa_pcm_get_property(GDBusConnection *conn,
 		return ba_variant_new_channels(t);
 	if (strcmp(property, "Sampling") == 0)
 		return ba_variant_new_sampling(t);
+	if (strcmp(property, "Format") == 0)
+		return ba_variant_new_format(t);
 	if (strcmp(property, "Codec") == 0)
 		return ba_variant_new_codec(t);
 	if (strcmp(property, "Delay") == 0)
@@ -491,6 +498,7 @@ int bluealsa_dbus_transport_register(struct ba_transport *t, GError **error) {
 	g_variant_builder_add(&props, "{sv}", "Modes", ba_variant_new_pcm_modes(t));
 	g_variant_builder_add(&props, "{sv}", "Channels", ba_variant_new_channels(t));
 	g_variant_builder_add(&props, "{sv}", "Sampling", ba_variant_new_sampling(t));
+	g_variant_builder_add(&props, "{sv}", "Format", ba_variant_new_format(t));
 	g_variant_builder_add(&props, "{sv}", "Codec", ba_variant_new_codec(t));
 	g_variant_builder_add(&props, "{sv}", "Delay", ba_variant_new_delay(t));
 	g_variant_builder_add(&props, "{sv}", "Volume", ba_variant_new_volume(t));
@@ -512,6 +520,8 @@ void bluealsa_dbus_transport_update(struct ba_transport *t, unsigned int mask) {
 		g_variant_builder_add(&props, "{sv}", "Channels", ba_variant_new_channels(t));
 	if (mask & BA_DBUS_TRANSPORT_UPDATE_SAMPLING)
 		g_variant_builder_add(&props, "{sv}", "Sampling", ba_variant_new_sampling(t));
+	if (mask & BA_DBUS_TRANSPORT_UPDATE_FORMAT)
+		g_variant_builder_add(&props, "{sv}", "Format", ba_variant_new_format(t));
 	if (mask & BA_DBUS_TRANSPORT_UPDATE_CODEC)
 		g_variant_builder_add(&props, "{sv}", "Codec", ba_variant_new_codec(t));
 	if (mask & BA_DBUS_TRANSPORT_UPDATE_DELAY)

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -155,7 +155,7 @@ int bluealsa_dbus_manager_register(GError **error) {
  * Data associated with a single PCM controller session. */
 struct bluealsa_ctrl_data {
 	struct ba_transport *t;
-	struct ba_pcm *pcm;
+	struct ba_transport_pcm *pcm;
 };
 
 static gboolean bluealsa_pcm_controller(GIOChannel *ch, GIOCondition condition,
@@ -225,7 +225,7 @@ static void bluealsa_pcm_open(GDBusMethodInvocation *inv, void *userdata) {
 		goto fail;
 	}
 
-	struct ba_pcm *pcm = NULL;
+	struct ba_transport_pcm *pcm = NULL;
 	if ((is_source && t->type.profile & BA_TRANSPORT_PROFILE_A2DP_SOURCE) ||
 			(!is_source && t->type.profile & BA_TRANSPORT_PROFILE_A2DP_SINK))
 		pcm = &t->a2dp.pcm;

--- a/src/bluealsa-dbus.h
+++ b/src/bluealsa-dbus.h
@@ -25,6 +25,7 @@
 #define BA_DBUS_TRANSPORT_UPDATE_DELAY    (1 << 3)
 #define BA_DBUS_TRANSPORT_UPDATE_VOLUME   (1 << 4)
 #define BA_DBUS_TRANSPORT_UPDATE_BATTERY  (1 << 5)
+#define BA_DBUS_TRANSPORT_UPDATE_FORMAT   (1 << 6)
 
 int bluealsa_dbus_manager_register(GError **error);
 

--- a/src/bluealsa-iface.c
+++ b/src/bluealsa-iface.c
@@ -115,6 +115,10 @@ static const GDBusPropertyInfo bluealsa_iface_pcm_Sampling = {
 	-1, "Sampling", "u", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
 };
 
+static const GDBusPropertyInfo bluealsa_iface_pcm_Format = {
+	-1, "Format", "q", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
+};
+
 static const GDBusPropertyInfo bluealsa_iface_pcm_Codec = {
 	-1, "Codec", "q", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
 };

--- a/src/io.c
+++ b/src/io.c
@@ -91,7 +91,7 @@ static void io_thread_scale_pcm(const struct ba_transport *t, int16_t *buffer,
 
 /**
  * Read PCM signal from the transport PCM FIFO. */
-static ssize_t io_thread_read_pcm(struct ba_pcm *pcm, int16_t *buffer, size_t samples) {
+static ssize_t io_thread_read_pcm(struct ba_transport_pcm *pcm, int16_t *buffer, size_t samples) {
 
 	ssize_t ret;
 
@@ -119,7 +119,7 @@ static ssize_t io_thread_read_pcm(struct ba_pcm *pcm, int16_t *buffer, size_t sa
 
 /**
  * Flush read buffer of the transport PCM FIFO. */
-static ssize_t io_thread_read_pcm_flush(struct ba_pcm *pcm) {
+static ssize_t io_thread_read_pcm_flush(struct ba_transport_pcm *pcm) {
 	ssize_t rv = splice(pcm->fd, NULL, config.null_fd, NULL, 1024 * 32, SPLICE_F_NONBLOCK);
 	if (rv == -1 && errno == EAGAIN)
 		rv = 0;
@@ -132,7 +132,7 @@ static ssize_t io_thread_read_pcm_flush(struct ba_pcm *pcm) {
  *
  * Note:
  * This function temporally re-enables thread cancellation! */
-static ssize_t io_thread_write_pcm(struct ba_pcm *pcm, const int16_t *buffer, size_t samples) {
+static ssize_t io_thread_write_pcm(struct ba_transport_pcm *pcm, const int16_t *buffer, size_t samples) {
 
 	struct pollfd pfd = { pcm->fd, POLLOUT, 0 };
 	const uint8_t *head = (uint8_t *)buffer;

--- a/src/shared/dbus-client.c
+++ b/src/shared/dbus-client.c
@@ -563,6 +563,11 @@ static dbus_bool_t bluealsa_dbus_message_iter_get_pcm_props_cb(const char *key,
 			goto fail;
 		dbus_message_iter_get_basic(variant, &pcm->sampling);
 	}
+	else if (strcmp(key, "Format") == 0) {
+		if (type != (type_expected = DBUS_TYPE_UINT16))
+			goto fail;
+		dbus_message_iter_get_basic(variant, &pcm->format);
+	}
 	else if (strcmp(key, "Codec") == 0) {
 		if (type != (type_expected = DBUS_TYPE_UINT16))
 			goto fail;

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -53,6 +53,8 @@ struct ba_pcm {
 	unsigned char channels;
 	/* PCM sampling frequency */
 	dbus_uint32_t sampling;
+	/* PCM format */
+	dbus_uint16_t format;
 
 	/* device address */
 	bdaddr_t addr;

--- a/src/utils.c
+++ b/src/utils.c
@@ -17,6 +17,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <alsa/asoundlib.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
@@ -234,6 +235,10 @@ const char *g_dbus_transport_type_to_bluez_object_path(struct ba_transport_type 
 		return "/HSP/AudioGateway";
 	}
 	return "/";
+}
+
+uint16_t g_dbus_transport_get_pcm_format(const struct ba_transport_type type) {
+	return SND_PCM_FORMAT_S16_LE;
 }
 
 /**

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,6 +34,7 @@ const char *batostr_(const bdaddr_t *ba);
 int g_dbus_bluez_object_path_to_hci_dev_id(const char *path);
 bdaddr_t *g_dbus_bluez_object_path_to_bdaddr(const char *path, bdaddr_t *addr);
 const char *g_dbus_transport_type_to_bluez_object_path(struct ba_transport_type type);
+uint16_t g_dbus_transport_get_pcm_format(const struct ba_transport_type type);
 
 GVariantIter *g_dbus_get_managed_objects(GDBusConnection *conn,
 		const char *name, const char *path, GError **error);

--- a/test/server-mock.c
+++ b/test/server-mock.c
@@ -152,7 +152,7 @@ void *io_thread_a2dp_sink_sbc(void *arg) {
 		int samples = sizeof(buffer) / sizeof(int16_t);
 		x = snd_pcm_sine_s16le(buffer, samples, 2, x, 0.01);
 
-		if (io_thread_write_pcm(&t->a2dp.pcm, buffer, samples) == -1)
+		if (io_thread_write_pcm(&t->a2dp.pcm, buffer, sizeof(buffer), samples) == -1)
 			error("FIFO write error: %s", strerror(errno));
 
 		asrsync_sync(&asrs, samples / 2);

--- a/utils/aplay.c
+++ b/utils/aplay.c
@@ -81,11 +81,10 @@ static void main_loop_stop(int sig) {
 	main_loop_on = false;
 }
 
-static int pcm_set_hw_params(snd_pcm_t *pcm, int channels, int rate,
+static int pcm_set_hw_params(snd_pcm_t *pcm, int channels, int rate, unsigned int format,
 		unsigned int *buffer_time, unsigned int *period_time, char **msg) {
 
 	const snd_pcm_access_t access = SND_PCM_ACCESS_RW_INTERLEAVED;
-	const snd_pcm_format_t format = SND_PCM_FORMAT_S16_LE;
 	snd_pcm_hw_params_t *params;
 	char buf[256];
 	int dir;
@@ -174,7 +173,7 @@ fail:
 	return err;
 }
 
-static int pcm_open(snd_pcm_t **pcm, int channels, int rate,
+static int pcm_open(snd_pcm_t **pcm, int channels, int rate, unsigned int format,
 		unsigned int *buffer_time, unsigned int *period_time, char **msg) {
 
 	snd_pcm_t *_pcm = NULL;
@@ -187,7 +186,7 @@ static int pcm_open(snd_pcm_t **pcm, int channels, int rate,
 		goto fail;
 	}
 
-	if ((err = pcm_set_hw_params(_pcm, channels, rate, buffer_time, period_time, &tmp)) != 0) {
+	if ((err = pcm_set_hw_params(_pcm, channels, rate, format, buffer_time, period_time, &tmp)) != 0) {
 		snprintf(buf, sizeof(buf), "Set HW params: %s", tmp);
 		goto fail;
 	}
@@ -299,14 +298,14 @@ static void *pcm_worker_routine(void *arg) {
 	struct pcm_worker *w = (struct pcm_worker *)arg;
 
 	size_t pcm_1s_samples = w->ba_pcm.sampling * w->ba_pcm.channels;
-	ffb_int16_t buffer = { 0 };
+	ffb_uint8_t buffer = { 0 };
 
 	/* Cancellation should be possible only in the carefully selected place
 	 * in order to prevent memory leaks and resources not being released. */
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 
 	pthread_cleanup_push(PTHREAD_CLEANUP(pcm_worker_routine_exit), w);
-	pthread_cleanup_push(PTHREAD_CLEANUP(ffb_int16_free), &buffer);
+	pthread_cleanup_push(PTHREAD_CLEANUP(ffb_uint8_free), &buffer);
 
 	/* create buffer big enough to hold 100 ms of PCM data */
 	if (ffb_init(&buffer, pcm_1s_samples / 10) == NULL) {
@@ -330,7 +329,7 @@ static void *pcm_worker_routine(void *arg) {
 	/* These variables determine how and when the pause command will be send
 	 * to the device player. In order not to flood BT connection with AVRCP
 	 * packets, we are going to send pause command every 0.5 second. */
-	size_t pause_threshold = pcm_1s_samples / 2 * sizeof(int16_t);
+	size_t pause_threshold = snd_pcm_format_size(w->ba_pcm.format, pcm_1s_samples / 2);
 	size_t pause_counter = 0;
 	size_t pause_bytes = 0;
 
@@ -374,7 +373,7 @@ static void *pcm_worker_routine(void *arg) {
 
 		#define MIN(a,b) a < b ? a : b
 		size_t _in = MIN(pcm_max_read_len, ffb_len_in(&buffer));
-		if ((ret = read(w->ba_pcm_fd, buffer.tail, _in * sizeof(int16_t))) == -1) {
+		if ((ret = read(w->ba_pcm_fd, buffer.tail, snd_pcm_format_size(w->ba_pcm.format, _in))) == -1) {
 			if (errno == EINTR)
 				continue;
 			error("PCM FIFO read error: %s", strerror(errno));
@@ -414,7 +413,7 @@ static void *pcm_worker_routine(void *arg) {
 				continue;
 			}
 
-			if (pcm_open(&w->pcm, w->ba_pcm.channels, w->ba_pcm.sampling,
+			if (pcm_open(&w->pcm, w->ba_pcm.channels, w->ba_pcm.sampling, w->ba_pcm.format,
 						&buffer_time, &period_time, &tmp) != 0) {
 				warn("Couldn't open PCM: %s", tmp);
 				pcm_max_read_len = buffer.size;
@@ -432,11 +431,13 @@ static void *pcm_worker_routine(void *arg) {
 						"  PCM buffer time: %u us (%zu bytes)\n"
 						"  PCM period time: %u us (%zu bytes)\n"
 						"  Sampling rate: %u Hz\n"
-						"  Channels: %u\n",
+						"  Channels: %u\n"
+						"  Format: %s\n",
 						w->addr,
 						buffer_time, snd_pcm_frames_to_bytes(w->pcm, buffer_size),
 						period_time, snd_pcm_frames_to_bytes(w->pcm, period_size),
-						w->ba_pcm.sampling, w->ba_pcm.channels);
+						w->ba_pcm.sampling, w->ba_pcm.channels,
+						snd_pcm_format_name(w->ba_pcm.format));
 			}
 
 		}
@@ -446,7 +447,7 @@ static void *pcm_worker_routine(void *arg) {
 		timeout = 500;
 
 		/* calculate the overall number of frames in the buffer */
-		ffb_seek(&buffer, ret / sizeof(*buffer.data));
+		ffb_seek(&buffer, ret / snd_pcm_format_size(w->ba_pcm.format, 1));
 		snd_pcm_sframes_t frames = ffb_len_out(&buffer) / w->ba_pcm.channels;
 
 		if ((frames = snd_pcm_writei(w->pcm, buffer.data, frames)) < 0)


### PR DESCRIPTION
Currently the audio output is limited to signed 16-bit (S16_LE). This PR allows to use different PCM audio format in the future. This is necessary if a library decodes samples into a different audio format, e.g. S24_3LE (libopenaptx does it).