### PR TITLE
Fix 'Invalid argument' when setting buffer_time

### DIFF
--- a/utils/aplay.c
+++ b/utils/aplay.c
@@ -127,13 +127,13 @@ static int pcm_set_hw_params(snd_pcm_t *pcm, snd_pcm_format_t format, int channe
 		goto fail;
 	}
 	dir = 0;
-	if ((err = snd_pcm_hw_params_set_buffer_time_near(pcm, params, buffer_time, &dir)) != 0) {
-		snprintf(buf, sizeof(buf), "Set buffer time: %s: %u", snd_strerror(err), *buffer_time);
+	if ((err = snd_pcm_hw_params_set_period_time_near(pcm, params, period_time, &dir)) != 0) {
+		snprintf(buf, sizeof(buf), "Set period time: %s: %u", snd_strerror(err), *period_time);
 		goto fail;
 	}
 	dir = 0;
-	if ((err = snd_pcm_hw_params_set_period_time_near(pcm, params, period_time, &dir)) != 0) {
-		snprintf(buf, sizeof(buf), "Set period time: %s: %u", snd_strerror(err), *period_time);
+	if ((err = snd_pcm_hw_params_set_buffer_time_near(pcm, params, buffer_time, &dir)) != 0) {
+		snprintf(buf, sizeof(buf), "Set buffer time: %s: %u", snd_strerror(err), *buffer_time);
 		goto fail;
 	}
 	if ((err = snd_pcm_hw_params(pcm, params)) != 0) {


### PR DESCRIPTION
When running bluealsa-aplay on a AML 905X box I get
`bluealsa-aplay: W: Couldn't open PCM: Set HW params: Set buffer time: Invalid argument: 500000
` 
Setting period_time first (like alsa's aplay does) fixes it.