### PR TITLE
configure.ac: default to /etc for sysconfdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,14 @@ AC_ARG_WITH([alsaplugindir],
 	AS_HELP_STRING([--with-alsaplugindir=dir], [path where ALSA plugin files are stored]),
 	[alsaplugindir="$withval"],
 	[alsaplugindir=$($PKG_CONFIG --variable=libdir alsa)/alsa-lib])
+# unfortunately, for ALSA >= 1.1.7 the directory for add-on configuration files
+# is hard-coded as /etc/alsa/conf.d (unless the distribution has patched the
+# sources). So we use that value as default unless (for backwards compatibility)
+# the user to overrides it with --prefix or --sysconfdir
+if test "$sysconfdir" = '${prefix}/etc'; then
+	test x"$prefix" = xNONE && sysconfdir=/etc
+fi
+
 AC_ARG_WITH([alsaconfdir],
 	AS_HELP_STRING([--with-alsaconfdir=dir], [path to ALSA add-on configuration files]),
 	[alsaconfdir="$withval"],


### PR DESCRIPTION
without options, bluealsa configure by default places the alsa config file in /usr/etc/alsa/conf.d for alsa-lib >= 1.1.7, and so libasound does not load it into its configuration.

This PR uses a hard-coded /etc/alsa/conf.d as the default, so that configure should "just work" without options on a default alsa 1.1.7+ install. I've tried to maintain backwards compatibility with the --sysconfdir option

Alsa hard-codes this path here:
https://github.com/alsa-project/alsa-lib/blob/master/src/conf/alsa.conf
there is no substitution by autoconf variables so for the great majority of installations this PR should give the correct default outcome. 
