### PR TITLE
Fix missing include of <sys/time.h> header for struct timeval

### DIFF
--- a/src/hci.c
+++ b/src/hci.c
@@ -14,6 +14,7 @@
 #include <poll.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #include <bluetooth/bluetooth.h>


### PR DESCRIPTION
Commit 3e45a8a9405ee6b9c0b0b0bd47b5c234d080c9ff added the use of `struct timeval` which is defined in `<sys/time.h>` header file. The missing include breaks building bluez-alsa with the musl C library:

```
hci.c: In function ‘hci_sco_connect’:
hci.c:97:9: error: variable ‘tv’ has initializer but incomplete type
   97 |  struct timeval tv = { .tv_sec = 5 };
      |         ^~~~~~~
hci.c:97:25: error: ‘struct timeval’ has no member named ‘tv_sec’
   97 |  struct timeval tv = { .tv_sec = 5 };
      |                         ^~~~~~
hci.c:97:34: warning: excess elements in struct initializer
   97 |  struct timeval tv = { .tv_sec = 5 };
      |                                  ^
hci.c:97:34: note: (near initialization for ‘tv’)
hci.c:97:17: error: storage size of ‘tv’ isn’t known
   97 |  struct timeval tv = { .tv_sec = 5 };
      |                 ^~
make[5]: *** [Makefile:601: hci.o] Error 1
```