### PR TITLE
Add ALSA mixer volume control support to aplay

### DIFF
--- a/utils/aplay/Makefile.am
+++ b/utils/aplay/Makefile.am
@@ -11,7 +11,8 @@ bluealsa_aplay_SOURCES = \
 	../../src/shared/log.c \
 	alsa-pcm.c \
 	dbus.c \
-	aplay.c
+	aplay.c \
+	volume_mapping.c
 
 bluealsa_aplay_CFLAGS = \
 	-I$(top_srcdir)/src \

--- a/utils/aplay/volume_mapping.c
+++ b/utils/aplay/volume_mapping.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2010 Clemens Ladisch <clemens@ladisch.de>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * The functions in this file map the value ranges of ALSA mixer controls onto
+ * the interval 0..1.
+ *
+ * The mapping is designed so that the position in the interval is proportional
+ * to the volume as a human ear would perceive it (i.e., the position is the
+ * cubic root of the linear sample multiplication factor).  For controls with
+ * a small range (24 dB or less), the mapping is linear in the dB values so
+ * that each step has the same size visually.  Only for controls without dB
+ * information, a linear mapping of the hardware volume register values is used
+ * (this is the same algorithm as used in the old alsamixer).
+ *
+ * When setting the volume, 'dir' is the rounding direction:
+ * -1/0/1 = down/nearest/up.
+ */
+
+#define _ISOC99_SOURCE /* lrint() */
+#define _GNU_SOURCE /* exp10() */
+#include <math.h>
+#include <stdbool.h>
+#include "volume_mapping.h"
+
+#define MAX_LINEAR_DB_SCALE	24
+
+static inline bool use_linear_dB_scale(long dBmin, long dBmax)
+{
+	return dBmax - dBmin <= MAX_LINEAR_DB_SCALE * 100;
+}
+
+static long lrint_dir(double x, int dir)
+{
+	if (dir > 0)
+		return lrint(ceil(x));
+	else if (dir < 0)
+		return lrint(floor(x));
+	else
+		return lrint(x);
+}
+
+enum ctl_dir { PLAYBACK, CAPTURE };
+
+static int (* const get_dB_range[2])(snd_mixer_elem_t *, long *, long *) = {
+	snd_mixer_selem_get_playback_dB_range,
+	snd_mixer_selem_get_capture_dB_range,
+};
+static int (* const get_raw_range[2])(snd_mixer_elem_t *, long *, long *) = {
+	snd_mixer_selem_get_playback_volume_range,
+	snd_mixer_selem_get_capture_volume_range,
+};
+static int (* const get_dB[2])(snd_mixer_elem_t *, snd_mixer_selem_channel_id_t, long *) = {
+	snd_mixer_selem_get_playback_dB,
+	snd_mixer_selem_get_capture_dB,
+};
+static int (* const get_raw[2])(snd_mixer_elem_t *, snd_mixer_selem_channel_id_t, long *) = {
+	snd_mixer_selem_get_playback_volume,
+	snd_mixer_selem_get_capture_volume,
+};
+static int (* const set_dB[2])(snd_mixer_elem_t *, long, int) = {
+	snd_mixer_selem_set_playback_dB_all,
+	snd_mixer_selem_set_capture_dB_all,
+};
+static int (* const set_raw[2])(snd_mixer_elem_t *, long) = {
+	snd_mixer_selem_set_playback_volume_all,
+	snd_mixer_selem_set_capture_volume_all,
+};
+
+static double get_normalized_volume(snd_mixer_elem_t *elem,
+				    snd_mixer_selem_channel_id_t channel,
+				    enum ctl_dir ctl_dir)
+{
+	long min, max, value;
+	double normalized, min_norm;
+	int err;
+
+	err = get_dB_range[ctl_dir](elem, &min, &max);
+	if (err < 0 || min >= max) {
+		err = get_raw_range[ctl_dir](elem, &min, &max);
+		if (err < 0 || min == max)
+			return 0;
+
+		err = get_raw[ctl_dir](elem, channel, &value);
+		if (err < 0)
+			return 0;
+
+		return (value - min) / (double)(max - min);
+	}
+
+	err = get_dB[ctl_dir](elem, channel, &value);
+	if (err < 0)
+		return 0;
+
+	if (use_linear_dB_scale(min, max))
+		return (value - min) / (double)(max - min);
+
+	normalized = exp10((value - max) / 6000.0);
+	if (min != SND_CTL_TLV_DB_GAIN_MUTE) {
+		min_norm = exp10((min - max) / 6000.0);
+		normalized = (normalized - min_norm) / (1 - min_norm);
+	}
+
+	return normalized;
+}
+
+static int set_normalized_volume(snd_mixer_elem_t *elem,
+				 double volume,
+				 int dir,
+				 enum ctl_dir ctl_dir)
+{
+	long min, max, value;
+	double min_norm;
+	int err;
+
+	err = get_dB_range[ctl_dir](elem, &min, &max);
+	if (err < 0 || min >= max) {
+		err = get_raw_range[ctl_dir](elem, &min, &max);
+		if (err < 0)
+			return err;
+
+		value = lrint_dir(volume * (max - min), dir) + min;
+		return set_raw[ctl_dir](elem, value);
+	}
+
+	if (use_linear_dB_scale(min, max)) {
+		value = lrint_dir(volume * (max - min), dir) + min;
+		return set_dB[ctl_dir](elem, value, dir);
+	}
+
+	if (min != SND_CTL_TLV_DB_GAIN_MUTE) {
+		min_norm = exp10((min - max) / 6000.0);
+		volume = volume * (1 - min_norm) + min_norm;
+	}
+	value = lrint_dir(6000.0 * log10(volume), dir) + max;
+	return set_dB[ctl_dir](elem, value, dir);
+}
+
+double get_normalized_playback_volume(snd_mixer_elem_t *elem,
+				      snd_mixer_selem_channel_id_t channel)
+{
+	return get_normalized_volume(elem, channel, PLAYBACK);
+}
+
+double get_normalized_capture_volume(snd_mixer_elem_t *elem,
+				     snd_mixer_selem_channel_id_t channel)
+{
+	return get_normalized_volume(elem, channel, CAPTURE);
+}
+
+int set_normalized_playback_volume(snd_mixer_elem_t *elem,
+				   double volume,
+				   int dir)
+{
+	return set_normalized_volume(elem, volume, dir, PLAYBACK);
+}
+
+int set_normalized_capture_volume(snd_mixer_elem_t *elem,
+				  double volume,
+				  int dir)
+{
+	return set_normalized_volume(elem, volume, dir, CAPTURE);
+}

--- a/utils/aplay/volume_mapping.c
+++ b/utils/aplay/volume_mapping.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2010 Clemens Ladisch <clemens@ladisch.de>
+ * Copyright (c) 2018 Max Kellermann <max@musicpd.org>
+ * Copyright (c) 2018 Stefano Miccoli <stefano.miccoli@polimi.it>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -132,9 +134,23 @@ static int set_normalized_volume(snd_mixer_elem_t *elem,
 		if (err < 0)
 			return err;
 
+		/* two special cases to avoid rounding errors at 0% and
+		   100% */
+		if (volume <= 0)
+			return set_raw[ctl_dir](elem, min);
+		else if (volume >= 1)
+			return set_raw[ctl_dir](elem, max);
+
 		value = lrint_dir(volume * (max - min), dir) + min;
 		return set_raw[ctl_dir](elem, value);
 	}
+
+	/* two special cases to avoid rounding errors at 0% and
+	   100% */
+	if (volume <= 0)
+		return set_dB[ctl_dir](elem, min, dir);
+	else if (volume >= 1)
+		return set_dB[ctl_dir](elem, max, dir);
 
 	if (use_linear_dB_scale(min, max)) {
 		value = lrint_dir(volume * (max - min), dir) + min;

--- a/utils/aplay/volume_mapping.h
+++ b/utils/aplay/volume_mapping.h
@@ -1,0 +1,17 @@
+#ifndef VOLUME_MAPPING_H_INCLUDED
+#define VOLUME_MAPPING_H_INCLUDED
+
+#include <alsa/asoundlib.h>
+
+double get_normalized_playback_volume(snd_mixer_elem_t *elem,
+				      snd_mixer_selem_channel_id_t channel);
+double get_normalized_capture_volume(snd_mixer_elem_t *elem,
+				     snd_mixer_selem_channel_id_t channel);
+int set_normalized_playback_volume(snd_mixer_elem_t *elem,
+				   double volume,
+				   int dir);
+int set_normalized_capture_volume(snd_mixer_elem_t *elem,
+				  double volume,
+				  int dir);
+
+#endif


### PR DESCRIPTION
Add a new command line option `-M` or `--mixer=NAME` to allow using an ALSA mixer for volume control. For using the native volume control the bluealsa server needs to be started with the `--a2dp-volume` command line option, e.g.:

```
$ bluealsa -p a2dp-sink --a2dp-volume
$ bluealsa-aplay -D default -M Master --profile-a2dp XX:XX:XX:XX:XX:XX
```

Setting the volume works in both ways.

Note, that if the bluealsa server is started with `--a2dp-volume` and no mixer control name is passed to bluealsa-aplay, the volume will not change when the source changes the volume.

Closes: #125 