### PR TITLE
improve alsa pcm poll event generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,20 @@
 # BlueALSA - Makefile.am
-# Copyright (c) 2016-2018 Arkadiusz Bokowy
+# Copyright (c) 2016-2020 Arkadiusz Bokowy
 
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src utils
 
 if ENABLE_TEST
 SUBDIRS += test
+endif
+
+if WITH_COVERAGE
+cov:
+	$(MAKE) $(AM_MAKEFLAGS) check CFLAGS="$(CFLAGS) -O0 --coverage"
+	$(LCOV) --capture -d src -d test --exclude '/usr/*' --exclude "*/test/*" -o cov.info
+	$(GENHTML) -o coverage -t $(PACKAGE) cov.info
+clean-local:
+	find $(top_builddir) -name "*.gcno" -delete
+	find $(top_builddir) -name "*.gcda" -delete
+	rm -rf coverage cov.info
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,19 @@ AM_CONDITIONAL([ENABLE_DEBUG_TIME], [test "x$enable_debug_time" = "xyes"])
 AM_COND_IF([ENABLE_DEBUG_TIME], [
 	AC_DEFINE([DEBUG_TIME], [1], [Define to 1 if the debug timing is enabled.])
 ])
+
+# embedded test coverage
+AC_ARG_WITH([coverage],
+	AS_HELP_STRING([--with-coverage], [use lcov for test coverage reporting]))
+AM_CONDITIONAL([WITH_COVERAGE], [test "x$with_coverage" = "xyes"])
+AM_COND_IF([WITH_COVERAGE], [
+	AC_PATH_PROG(LCOV, lcov)
+	AC_PATH_PROG(GENHTML, genhtml)
+	AC_SUBST([LCOV])
+	AC_SUBST([GENHTML])
+])
+
+# in-place call-stack unwinding
 AC_ARG_WITH([libunwind],
 	AS_HELP_STRING([--with-libunwind], [use libunwind for call-stack unwinding]))
 AM_CONDITIONAL([WITH_LIBUNWIND], [test "x$with_libunwind" = "xyes"])

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -77,6 +77,9 @@ struct bluealsa_pcm {
 	snd_pcm_uframes_t io_hw_boundary;
 	snd_pcm_uframes_t io_hw_ptr;
 
+	/* permit the application to modify the frequency of poll() events */
+	volatile snd_pcm_uframes_t io_avail_min;
+
 	pthread_mutex_t delay_mutex;
 	struct timespec delay_ts;
 	snd_pcm_uframes_t delay_hw_ptr;
@@ -153,9 +156,9 @@ static void *io_thread(snd_pcm_ioplug_t *io) {
 			 * it should take for a real-time application to write the balance
 			 * of the period. */
 			if (!started && io->stream == SND_PCM_STREAM_PLAYBACK) {
-				if (io->period_size > io->appl_ptr) {
+				if (pcm->io_avail_min > io->appl_ptr) {
 					struct timespec ts = {
-						.tv_nsec = (io->period_size - io->appl_ptr) * 1000000000 / io->rate };
+						.tv_nsec = (pcm->io_avail_min - io->appl_ptr) * 1000000000 / io->rate };
 					debug2("IO thread started with insufficient frames - pausing for %ld ms", ts.tv_nsec / 1000000);
 					sigtimedwait(&sigset, NULL, &ts);
 					asrsync_init(&asrs, io->rate);
@@ -182,7 +185,7 @@ static void *io_thread(snd_pcm_ioplug_t *io) {
 		snd_pcm_uframes_t io_buffer_size = io->buffer_size;
 		snd_pcm_uframes_t io_hw_ptr = pcm->io_hw_ptr;
 		snd_pcm_uframes_t io_hw_boundary = pcm->io_hw_boundary;
-		snd_pcm_uframes_t frames = io->period_size;
+		snd_pcm_uframes_t frames = pcm->io_avail_min;
 		const snd_pcm_channel_area_t *areas = snd_pcm_ioplug_mmap_areas(io);
 		char *buffer = (char *)areas->addr + (areas->first + areas->step * io_ptr) / 8;
 		char *head = buffer;
@@ -394,6 +397,9 @@ static int bluealsa_hw_params(snd_pcm_ioplug_t *io, snd_pcm_hw_params_t *params)
 		debug2("FIFO buffer size: %zd", pcm->ba_pcm_buffer_size);
 	}
 
+	/* ALSA default for avail min is one period. */
+	pcm->io_avail_min = io->period_size;
+
 	debug2("Selected HW buffer: %zd periods x %zd bytes %c= %zd bytes",
 			io->buffer_size / io->period_size, pcm->frame_size * io->period_size,
 			io->period_size * (io->buffer_size / io->period_size) == io->buffer_size ? '=' : '<',
@@ -413,7 +419,18 @@ static int bluealsa_hw_free(snd_pcm_ioplug_t *io) {
 static int bluealsa_sw_params(snd_pcm_ioplug_t *io, snd_pcm_sw_params_t *params) {
 	struct bluealsa_pcm *pcm = io->private_data;
 	debug2("Initializing SW");
+
 	snd_pcm_sw_params_get_boundary(params, &pcm->io_hw_boundary);
+
+	snd_pcm_uframes_t avail_min;
+	snd_pcm_sw_params_get_avail_min(params, &avail_min);
+	if (avail_min != pcm->io_avail_min) {
+		if (avail_min > io->buffer_size)
+			return -EINVAL;
+		debug2("Changing SW avail min: %zu -> %zu", pcm->io_avail_min, avail_min);
+		pcm->io_avail_min = avail_min;
+	}
+
 	return 0;
 }
 
@@ -591,7 +608,7 @@ static int bluealsa_poll_revents(snd_pcm_ioplug_t *io, struct pollfd *pfd,
 			eventfd_write(pcm->event_fd, 1);
 
 		/* If the event was triggered prematurely, wait for another one. */
-		else if (!snd_pcm_avail_update(io->pcm))
+		else if (snd_pcm_avail_update(io->pcm) < (snd_pcm_sframes_t)pcm->io_avail_min)
 			*revents = 0;
 	}
 	else

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -599,12 +599,15 @@ static int bluealsa_poll_revents(snd_pcm_ioplug_t *io, struct pollfd *pfd,
 		unsigned int nfds, unsigned short *revents) {
 	struct bluealsa_pcm *pcm = io->private_data;
 
+	*revents = 0;
+	int ret = 0;
+
 	if (bluealsa_dbus_connection_poll_dispatch(&pcm->dbus_ctx, &pfd[1], nfds - 1))
 		while (dbus_connection_dispatch(pcm->dbus_ctx.conn) == DBUS_DISPATCH_DATA_REMAINS)
 			continue;
 
 	if (pcm->ba_pcm_fd == -1)
-		return -ENODEV;
+		goto fail;
 
 	if (pfd[0].revents & POLLIN) {
 
@@ -614,36 +617,52 @@ static int bluealsa_poll_revents(snd_pcm_ioplug_t *io, struct pollfd *pfd,
 		if (event & 0xDEAD0000)
 			goto fail;
 
+		/* This call synchronizes the ring buffer pointers and updates the
+		 * ioplug state. */
+		snd_pcm_uframes_t avail = snd_pcm_avail(io->pcm);
+
 		/* ALSA expects that the event will match stream direction, e.g.
 		 * playback will not start if the event is for reading. */
 		*revents = io->stream == SND_PCM_STREAM_CAPTURE ? POLLIN : POLLOUT;
 
-		/* Include POLLERR if PCM is not prepared, running or draining.
-		 * Also restore the event trigger as in this state the io thread is
-		 * not active to do it */
-		if (io->state != SND_PCM_STATE_PREPARED &&
-			 io->state != SND_PCM_STATE_RUNNING &&
-			 io->state != SND_PCM_STATE_DRAINING) {
-			*revents |= POLLERR;
-			eventfd_write(pcm->event_fd, 1);
-		}
+		/* We hold the event fd ready, unless insufficient frames are
+		 * available in the ring buffer. */
+		bool ready = true;
 
-		/* a playback application may write less than start_threshold frames on
-		 * its first write and then wait in poll() forever because the event_fd
-		 * never gets written to again.
-		 * To prevent this possibility, we bump the internal trigger. */
-		else if (snd_pcm_stream(io->pcm) == SND_PCM_STREAM_PLAYBACK &&
-			io->state == SND_PCM_STATE_PREPARED)
+		switch (io->state) {
+			case SND_PCM_STATE_SETUP:
+				ready = false;
+				*revents = 0;
+				break;
+			case SND_PCM_STATE_RUNNING:
+				if (avail < pcm->io_avail_min) {
+					ready = false;
+					*revents = 0;
+				}
+				break;
+			case SND_PCM_STATE_XRUN:
+			case SND_PCM_STATE_PAUSED:
+			case SND_PCM_STATE_SUSPENDED:
+				*revents = POLLERR;
+				break;
+			case SND_PCM_STATE_DISCONNECTED:
+				*revents = POLLERR;
+				ret = -ENODEV;
+				break;
+			case SND_PCM_STATE_OPEN:
+				*revents = POLLERR;
+				ret = -EBADF;
+				break;
+			default:
+				break;
+		};
+
+		if (ready)
 			eventfd_write(pcm->event_fd, 1);
 
-		/* If the event was triggered prematurely, wait for another one. */
-		else if (snd_pcm_avail_update(io->pcm) < (snd_pcm_sframes_t)pcm->io_avail_min)
-			*revents = 0;
 	}
-	else
-		*revents = 0;
 
-	return 0;
+	return ret;
 
 fail:
 	*revents = POLLERR | POLLHUP;

--- a/test/server-mock.c
+++ b/test/server-mock.c
@@ -17,10 +17,20 @@
 #endif
 
 #include <assert.h>
-#include <fcntl.h>
+#include <errno.h>
 #include <getopt.h>
-#include <sys/stat.h>
-#include <sys/types.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gio/gio.h>
+#include <glib.h>
 
 #include "inc/dbus.inc"
 #include "inc/sine.inc"

--- a/test/test-ba.c
+++ b/test/test-ba.c
@@ -55,6 +55,9 @@ START_TEST(test_ba_adapter) {
 	ck_assert_ptr_ne(a = ba_adapter_new(5), NULL);
 	ck_assert_int_eq(a->hci.dev_id, 5);
 	ck_assert_str_eq(a->hci.name, "hci5");
+
+	ck_assert_ptr_eq(ba_adapter_lookup(5), a);
+
 	ba_adapter_unref(a);
 
 } END_TEST
@@ -75,6 +78,8 @@ START_TEST(test_ba_device) {
 	ck_assert_int_eq(bacmp(&d->addr, &addr), 0);
 	ck_assert_str_eq(d->ba_dbus_path, "/org/bluealsa/hci0/dev_AB_90_78_56_34_12");
 	ck_assert_str_eq(d->bluez_dbus_path, "/org/bluez/hci0/dev_AB_90_78_56_34_12");
+
+	ck_assert_ptr_eq(ba_device_lookup(a, &addr), d);
 
 	ba_device_unref(d);
 
@@ -99,6 +104,8 @@ START_TEST(test_ba_transport) {
 	ck_assert_int_eq(t->type.profile, BA_TRANSPORT_PROFILE_NONE);
 	ck_assert_str_eq(t->bluez_dbus_owner, "/owner");
 	ck_assert_str_eq(t->bluez_dbus_path, "/path");
+
+	ck_assert_ptr_eq(ba_transport_lookup(d, "/path"), t);
 
 	ba_transport_unref(t);
 

--- a/test/test-msbc.c
+++ b/test/test-msbc.c
@@ -1,6 +1,6 @@
 /*
  * test-msbc.c
- * Copyright (c) 2016-2018 Arkadiusz Bokowy
+ * Copyright (c) 2016-2020 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -17,6 +17,25 @@
 #include "../src/shared/log.c"
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+START_TEST(test_msbc_init) {
+
+	struct esco_msbc msbc = { .initialized = false };
+
+	ck_assert_int_eq(msbc_init(&msbc), 0);
+	ck_assert_int_eq(msbc.initialized, true);
+	ck_assert_int_eq(ffb_len_out(&msbc.enc_pcm), 0);
+
+	ffb_seek(&msbc.enc_pcm, 16);
+	ck_assert_int_eq(ffb_len_out(&msbc.enc_pcm), 16);
+
+	ck_assert_int_eq(msbc_init(&msbc), 0);
+	ck_assert_int_eq(msbc.initialized, true);
+	ck_assert_int_eq(ffb_len_out(&msbc.enc_pcm), 0);
+
+	msbc_finish(&msbc);
+
+} END_TEST
 
 START_TEST(test_msbc_find_h2_header) {
 
@@ -126,6 +145,7 @@ int main(void) {
 
 	suite_add_tcase(s, tc);
 
+	tcase_add_test(tc, test_msbc_init);
 	tcase_add_test(tc, test_msbc_find_h2_header);
 	tcase_add_test(tc, test_msbc_encode_decode);
 


### PR DESCRIPTION
for playback, implement support for avail_min sw parameter, and generate internal events during the time synchronization sleep, so that applications can continue to write while the io thread sleeps.

this change enables using bluealsa with alsaloop, for example, and possibly other applications that attempt to synchronize 2 pcms with managed latency.