### PR TITLE
make SRV the last alsa config argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,13 @@ most straightforward method is to use BlueZ CLI utility called `bluetoothctl`. W
 connected one can use the `bluealsa` virtual PCM device as follows:
 
 ```sh
-aplay -D bluealsa:SRV=org.bluealsa,DEV=XX:XX:XX:XX:XX:XX,PROFILE=a2dp Bourree_in_E_minor.wav
+aplay -D bluealsa:DEV=XX:XX:XX:XX:XX:XX,PROFILE=a2dp Bourree_in_E_minor.wav
+```
+
+or, from bluealsa release 3.0.0 onwards:
+
+```sh
+aplay -D bluealsa:XX:XX:XX:XX:XX:XX,a2dp Bourree_in_E_minor.wav
 ```
 
 Setup parameters of the bluealsa PCM device can be set in the local `.asoundrc` configuration file
@@ -121,7 +127,7 @@ related part of the specification, or use [oFono](https://01.org/ofono) service 
 order to open SCO audio connection one shall switch to `sco` profile like follows:
 
 ```sh
-aplay -D bluealsa:SRV=org.bluealsa,DEV=XX:XX:XX:XX:XX:XX,PROFILE=sco Bourree_in_E_minor.wav
+aplay -D bluealsa:DEV=XX:XX:XX:XX:XX:XX,PROFILE=sco Bourree_in_E_minor.wav
 ```
 
 The list of available BlueALSA PCMs (provided by connected Bluetooth devices with audio

--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -1,24 +1,24 @@
 # BlueALSA integration setup
 
-defaults.bluealsa.service "org.bluealsa"
 defaults.bluealsa.profile "a2dp"
 defaults.bluealsa.delay 20000
 defaults.bluealsa.battery "yes"
+defaults.bluealsa.service "org.bluealsa"
 
 ctl.bluealsa {
-	@args [ SRV BAT ]
-	@args.SRV {
-		type string
-		default {
-			@func refer
-			name defaults.bluealsa.service
-		}
-	}
+	@args [ BAT SRV ]
 	@args.BAT {
 		type string
 		default {
 			@func refer
 			name defaults.bluealsa.battery
+		}
+	}
+	@args.SRV {
+		type string
+		default {
+			@func refer
+			name defaults.bluealsa.service
 		}
 	}
 	type bluealsa
@@ -27,14 +27,7 @@ ctl.bluealsa {
 }
 
 pcm.bluealsa {
-	@args [ SRV DEV PROFILE DELAY ]
-	@args.SRV {
-		type string
-		default {
-			@func refer
-			name defaults.bluealsa.service
-		}
-	}
+	@args [ DEV PROFILE DELAY SRV ]
 	@args.DEV {
 		type string
 		default {
@@ -54,6 +47,13 @@ pcm.bluealsa {
 		default {
 			@func refer
 			name defaults.bluealsa.delay
+		}
+	}
+	@args.SRV {
+		type string
+		default {
+			@func refer
+			name defaults.bluealsa.service
 		}
 	}
 	type plug


### PR DESCRIPTION
This change allows simpler pcm naming using positional parameters, such as `bluealsa:00:11:22:33:44:55,a2dp`