### PR TITLE
Alsa pcm updates

### DIFF
--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -79,10 +79,15 @@ struct bluealsa_pcm {
 	struct timespec delay_ts;
 	snd_pcm_uframes_t delay_hw_ptr;
 	unsigned int delay_pcm_nread;
-	bool delay_valid;
+	/* In capture mode, delay_running indicates that frames are being
+	 * transfered to the FIFO by the server, in playback mode it indicates
+	 * the io thread is transfering frames to the FIFO. */
+	bool delay_running;
 
 	/* delay accumulated just before pausing */
 	snd_pcm_sframes_t delay_paused;
+	/* maximum delay in FIFO */
+	snd_pcm_sframes_t delay_fifo_size;
 	/* user provided extra delay component */
 	snd_pcm_sframes_t delay_ex;
 
@@ -158,6 +163,33 @@ static void io_thread_wait_first_period(snd_pcm_ioplug_t *io) {
 		};
 		nanosleep(&ts, NULL);
 	}
+}
+
+/**
+ * Helper function for IO thread delay calculation. */
+static void io_thread_update_delay(struct bluealsa_pcm *pcm,
+                                                   snd_pcm_sframes_t hw_ptr) {
+	struct timespec now;
+	unsigned int nread = 0;
+
+	gettimestamp(&now);
+	ioctl(pcm->ba_pcm_fd, FIONREAD, &nread);
+
+	/* stash current time and levels */
+	pthread_mutex_lock(&pcm->mutex);
+	pcm->delay_ts = now;
+	pcm->delay_pcm_nread = nread;
+	if (hw_ptr == -1) {
+		pcm->delay_hw_ptr = 0;
+		if (pcm->io.stream == SND_PCM_STREAM_PLAYBACK)
+			pcm->delay_running = false;
+	}
+	else {
+		pcm->delay_hw_ptr = hw_ptr;
+		if (pcm->io.stream == SND_PCM_STREAM_PLAYBACK)
+			pcm->delay_running = true;
+	}
+	pthread_mutex_unlock(&pcm->mutex);
 }
 
 /**
@@ -243,6 +275,7 @@ static void *io_thread(snd_pcm_ioplug_t *io) {
 		snd_pcm_uframes_t avail = snd_pcm_ioplug_hw_avail(io, io_hw_ptr, io->appl_ptr);
 		if (avail == 0) {
 			io_hw_ptr = -1;
+			io_thread_update_delay(pcm, 0);
 			goto sync;
 		}
 
@@ -292,6 +325,7 @@ static void *io_thread(snd_pcm_ioplug_t *io) {
 			if (ret == 0)
 				goto fail;
 
+			io_thread_update_delay(pcm, io_hw_ptr);
 		}
 		else {
 
@@ -308,19 +342,7 @@ static void *io_thread(snd_pcm_ioplug_t *io) {
 				len -= ret;
 			} while (len != 0);
 
-			struct timespec now;
-			unsigned int nread = 0;
-
-			gettimestamp(&now);
-			ioctl(pcm->ba_pcm_fd, FIONREAD, &nread);
-
-			/* stash current time and levels */
-			pthread_mutex_lock(&pcm->mutex);
-			pcm->delay_ts = now;
-			pcm->delay_hw_ptr = io_hw_ptr;
-			pcm->delay_pcm_nread = nread;
-			pcm->delay_valid = true;
-			pthread_mutex_unlock(&pcm->mutex);
+			io_thread_update_delay(pcm, io_hw_ptr);
 
 			/* synchronize playback time */
 			asrsync_sync(&asrs, frames);
@@ -364,13 +386,18 @@ static int bluealsa_start(snd_pcm_ioplug_t *io) {
 		return 0;
 	}
 
-	/* initialize delay calculation */
-	pcm->delay_valid = false;
-
 	if (!bluealsa_dbus_pcm_ctrl_send_resume(pcm->ba_pcm_ctrl_fd, NULL)) {
 		debug2("Couldn't start PCM: %s", strerror(errno));
 		return -errno;
 	}
+
+	/* Initialize delay calculation - capture reception begins immediately,
+	 * playback transmission begins only when first period has been written
+	 * by the application. */
+	pcm->delay_running = io->stream == SND_PCM_STREAM_CAPTURE ? true : false;
+	struct timespec now;
+	gettimestamp(&now);
+	pcm->delay_ts = now;
 
 	/* start the IO thread */
 	pcm->io_started = true;
@@ -394,7 +421,8 @@ static int bluealsa_stop(snd_pcm_ioplug_t *io) {
 		pthread_cancel(pcm->io_thread);
 		pthread_join(pcm->io_thread, NULL);
 	}
-	pcm->delay_valid = false;
+	pcm->delay_running = false;
+	pcm->delay_pcm_nread = 0;
 
 	/* Bug in ioplug - if pcm->io_hw_ptr == -1 then it reports state
 	 * SND_PCM_STATE_XRUN instead of SND_PCM_STATE_SETUP after pcm is stopped */
@@ -447,16 +475,19 @@ static int bluealsa_hw_params(snd_pcm_ioplug_t *io, snd_pcm_hw_params_t *params)
 		return -EBUSY;
 	}
 
-	if (pcm->io.stream == SND_PCM_STREAM_PLAYBACK) {
+	if (pcm->io.stream == SND_PCM_STREAM_PLAYBACK)
 		/* By default, the size of the pipe buffer is set to a too large value for
 		 * our purpose. On modern Linux system it is 65536 bytes. Large buffer in
 		 * the playback mode might contribute to an unnecessary audio delay. Since
 		 * it is possible to modify the size of this buffer we will set is to some
 		 * low value, but big enough to prevent audio tearing. Note, that the size
 		 * will be rounded up to the page size (typically 4096 bytes). */
-		pcm->ba_pcm_buffer_size = fcntl(pcm->ba_pcm_fd, F_SETPIPE_SZ, 2048);
-		debug2("FIFO buffer size: %zd", pcm->ba_pcm_buffer_size);
-	}
+		pcm->delay_fifo_size = fcntl(pcm->ba_pcm_fd, F_SETPIPE_SZ, 2048) / pcm->frame_size;
+	else
+		pcm->delay_fifo_size = fcntl(pcm->ba_pcm_fd, F_GETPIPE_SZ)  / pcm->frame_size;
+
+	debug2("FIFO buffer size: %zd frames", pcm->delay_fifo_size);
+
 
 	/* ALSA default for avail min is one period. */
 	pcm->io_avail_min = io->period_size;
@@ -542,40 +573,66 @@ static snd_pcm_sframes_t bluealsa_calculate_delay(snd_pcm_ioplug_t *io) {
 
 	snd_pcm_sframes_t delay = 0;
 
-	if (!pcm->delay_valid) {
-		/* If we have never transmitted anything, the delay is just based
-		 * on the current buffer length (transfered frames or unread frames
-		 * respectively for playback or capture). */
-		delay = snd_pcm_ioplug_hw_avail(io, io->hw_ptr, io->appl_ptr);
-		if (io->stream == SND_PCM_STREAM_CAPTURE)
-			delay = io->buffer_size - delay;
+	/* if PCM is not started there should be no capture delay */
+	if (!pcm->delay_running && io->stream == SND_PCM_STREAM_CAPTURE)
+		return 0;
+
+	struct timespec now;
+	gettimestamp(&now);
+
+	pthread_mutex_lock(&pcm->mutex);
+
+	struct timespec diff;
+	difftimespec(&now, &pcm->delay_ts, &diff);
+
+	/* tframes is the maximum number of frames that can have been
+	 * produced/consumed by the server since pcm->delay_ts. */
+	unsigned int tframes =
+		(diff.tv_sec * 1000 + diff.tv_nsec / 1000000) * io->rate / 1000;
+
+	/* fifo_delay is the number of frames that were in the fifo at pcm->delay_ts */
+	snd_pcm_uframes_t fifo_delay = pcm->delay_pcm_nread / pcm->frame_size;
+
+	if (io->stream == SND_PCM_STREAM_CAPTURE) {
+
+		/* start with maximum frames available in fifo since pcm->delay_ts. */
+		delay = fifo_delay + tframes;
+
+		/* adjust by the change in frames in the buffer. */
+		if (io->state != SND_PCM_STATE_XRUN)
+			delay += io->buffer_size - snd_pcm_ioplug_hw_avail(io, pcm->delay_hw_ptr, io->appl_ptr);
+
+		/* impose upper limit */
+		snd_pcm_uframes_t limit = pcm->delay_fifo_size + io->buffer_size;
+		if (delay > limit)
+			delay = limit;
 	}
 	else {
-		/* Take the gap between the current input pointer in this thread and
-		 * the last thing transmitted in the I/O thread and adjust that by the
-		 * amount of time that has passed since something was transmitted. */
+		delay = fifo_delay;
 
-		struct timespec now;
-		gettimestamp(&now);
+		/* buffer_delay is the number of frames that were in the buffer at
+		 * pcm->delay_ts, adjusted the number written by the application since
+		 * then. */
+		snd_pcm_sframes_t buffer_delay = 0;
+		if (io->state != SND_PCM_STATE_XRUN)
+			buffer_delay = snd_pcm_ioplug_hw_avail(io, pcm->delay_hw_ptr, io->appl_ptr);
 
-		pthread_mutex_lock(&pcm->mutex);
+		/* If the pcm is running, then some frames from the buffer may have been
+		 * consumed. */
+		if (pcm->delay_running)
+			delay += buffer_delay;
 
-		struct timespec diff;
-		difftimespec(&now, &pcm->delay_ts, &diff);
-
-		delay = snd_pcm_ioplug_hw_avail(io, pcm->delay_hw_ptr, io->appl_ptr);
-
-		delay += pcm->delay_pcm_nread / pcm->frame_size;
-
-		unsigned int tsamples =
-			(diff.tv_sec * 1000 + diff.tv_nsec / 1000000) * io->rate / 1000;
-		/* Do not allow us to have a negative number of samples queued! */
-		if ((delay = delay - tsamples) < 0)
+		/* Adjust the total delay by the number of frames consumed. */
+		if ((delay -= tframes) < 0)
 			delay = 0;
 
-		pthread_mutex_unlock(&pcm->mutex);
-
+		/* If the pcm is not running, then the frames in the buffer will not have
+		 * been consumed since pcm->delay_ts. */
+		if (!pcm->delay_running)
+			delay += buffer_delay;
 	}
+
+	pthread_mutex_unlock(&pcm->mutex);
 
 	/* data transfer (communication) and encoding/decoding */
 	delay += (io->rate / 100) * pcm->ba_pcm.delay / 100;
@@ -637,20 +694,32 @@ static int bluealsa_delay(snd_pcm_ioplug_t *io, snd_pcm_sframes_t *delayp) {
 	if (pcm->ba_pcm_fd == -1)
 		return -ENODEV;
 
-	/* For capture PCMs only, the delay must be reported as zero when an overrun
-	 * occurs. */
-	if (io->stream == SND_PCM_STREAM_CAPTURE && io->state == SND_PCM_STATE_XRUN) {
-		*delayp = 0;
-		return 0;
+	int ret = 0;
+	*delayp = 0;
+
+	switch (io->state) {
+		case SND_PCM_STATE_PREPARED:
+		case SND_PCM_STATE_RUNNING:
+			*delayp = bluealsa_calculate_delay(io);
+			break;
+		case SND_PCM_STATE_PAUSED:
+			*delayp = pcm->delay_paused;
+			break;
+		case SND_PCM_STATE_XRUN:
+			*delayp = bluealsa_calculate_delay(io);
+			ret = -EPIPE;
+			break;
+		case SND_PCM_STATE_SUSPENDED:
+			ret = -ESTRPIPE;
+			break;
+		case SND_PCM_STATE_DISCONNECTED:
+			ret = -ENODEV;
+			break;
+		default:
+			break;
 	}
 
-	/* When the PCM is paused, the delay value remains constant. */
-	if (io->state == SND_PCM_STATE_PAUSED)
-		*delayp = pcm->delay_paused;
-	else
-		*delayp = bluealsa_calculate_delay(io);
-
-	return 0;
+	return ret;
 }
 
 static int bluealsa_poll_descriptors_count(snd_pcm_ioplug_t *io) {

--- a/test/test-alsa-pcm.c
+++ b/test/test-alsa-pcm.c
@@ -249,10 +249,12 @@ START_TEST(test_capture_start) {
 	for (i = 0; i < buffer_size / period_size; i++)
 		ck_assert_int_eq(snd_pcm_readi(pcm, buffer, period_size), period_size);
 
-	/* after reading there should be no more than one period of data */
-	ck_assert_int_le(snd_pcm_avail(pcm), period_size);
+	/* after reading there should be no more than one period of data in buffer */
+	snd_pcm_sframes_t avail;
+	ck_assert_int_le((avail = snd_pcm_avail(pcm)), period_size);
+	/* but there may be more data in the FIFO */
 	ck_assert_int_eq(snd_pcm_delay(pcm, &delay), 0);
-	ck_assert_int_le(delay, period_size);
+	ck_assert_int_ge(delay, avail);
 
 	ck_assert_int_eq(test_pcm_close(pid, pcm), 0);
 


### PR DESCRIPTION
This completes the work I've been doing to provide better support for "difficult" applications such as alsaloop that require the bluealsa plugin to behave more like the hw plugin. alsaloop is now able to capture from bluealsa devices reliably, and even to capture from one bluealsa device and playback to another. As a side-effect, VLC appears to have reduced latency.