### PR TITLE
Provide ALSA control TLV data for dB calculation

### DIFF
--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -839,9 +839,9 @@ static int str2bdaddr(const char *str, bdaddr_t *ba) {
 
 static int str2profile(const char *str) {
 	if (strcasecmp(str, "a2dp") == 0)
-		return BA_PCM_FLAG_PROFILE_A2DP;
+		return BA_PCM_PROFILE_A2DP;
 	else if (strcasecmp(str, "sco") == 0)
-		return BA_PCM_FLAG_PROFILE_SCO;
+		return BA_PCM_PROFILE_SCO;
 	return 0;
 }
 
@@ -999,10 +999,10 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 		goto fail;
 	}
 
-	int flags = ba_profile | (
-			stream == SND_PCM_STREAM_PLAYBACK ? BA_PCM_FLAG_SINK : BA_PCM_FLAG_SOURCE);
 	debug("Getting BlueALSA PCM: %s %s %s", snd_pcm_stream_name(stream), device, profile);
-	if (!bluealsa_dbus_get_pcm(&pcm->dbus_ctx, &ba_addr, flags, &pcm->ba_pcm, &err)) {
+	if (!bluealsa_dbus_get_pcm(&pcm->dbus_ctx, &ba_addr, ba_profile,
+				stream == SND_PCM_STREAM_PLAYBACK ? BA_PCM_MODE_SINK : BA_PCM_MODE_SOURCE,
+				&pcm->ba_pcm, &err)) {
 		SNDERR("Couldn't get BlueALSA PCM: %s", err.message);
 		ret = -ENODEV;
 		goto fail;

--- a/src/shared/dbus-client.c
+++ b/src/shared/dbus-client.c
@@ -296,7 +296,8 @@ success:
 dbus_bool_t bluealsa_dbus_get_pcm(
 		struct ba_dbus_ctx *ctx,
 		const bdaddr_t *addr,
-		unsigned int flags,
+		unsigned int profile,
+		unsigned int modes,
 		struct ba_pcm *pcm,
 		DBusError *error) {
 
@@ -310,7 +311,8 @@ dbus_bool_t bluealsa_dbus_get_pcm(
 
 	for (i = 0; i < length; i++)
 		if (bacmp(&pcms[i].addr, addr) == 0 &&
-				(pcms[i].flags & flags) == flags) {
+				pcms[i].profile == profile &&
+				(pcms[i].modes & modes) == modes) {
 			memcpy(pcm, &pcms[i], sizeof(*pcm));
 			goto final;
 		}
@@ -588,18 +590,18 @@ static dbus_bool_t bluealsa_dbus_message_iter_get_pcm_props_cb(const char *key,
 			goto fail;
 		dbus_message_iter_get_basic(variant, &tmp);
 		if (strstr(tmp, "A2DP") != NULL)
-			pcm->flags |= BA_PCM_FLAG_PROFILE_A2DP;
+			pcm->profile = BA_PCM_PROFILE_A2DP;
 		else
-			pcm->flags |= BA_PCM_FLAG_PROFILE_SCO;
+			pcm->profile = BA_PCM_PROFILE_SCO;
 	}
 	else if (strcmp(key, "Mode") == 0) {
 		if (type != (type_expected = DBUS_TYPE_STRING))
 			goto fail;
 		dbus_message_iter_get_basic(variant, &tmp);
 		if (strcmp(tmp, "source") == 0)
-			pcm->flags |= BA_PCM_FLAG_SOURCE;
+			pcm->modes |= BA_PCM_MODE_SOURCE;
 		else if (strcmp(tmp, "sink") == 0)
-			pcm->flags |= BA_PCM_FLAG_SINK;
+			pcm->modes |= BA_PCM_MODE_SINK;
 	}
 	else if (strcmp(key, "Format") == 0) {
 		if (type != (type_expected = DBUS_TYPE_UINT16))

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -21,10 +21,10 @@
 #define BLUEALSA_INTERFACE_PCM     "org.bluealsa.PCM1"
 #define BLUEALSA_INTERFACE_RFCOMM  "org.bluealsa.RFCOMM1"
 
-#define BA_PCM_FLAG_SOURCE       (1 << 0)
-#define BA_PCM_FLAG_SINK         (1 << 1)
-#define BA_PCM_FLAG_PROFILE_A2DP (1 << 2)
-#define BA_PCM_FLAG_PROFILE_SCO  (1 << 3)
+#define BA_PCM_PROFILE_A2DP      (1 << 0)
+#define BA_PCM_PROFILE_SCO       (1 << 1)
+#define BA_PCM_MODE_SOURCE       (1 << 0)
+#define BA_PCM_MODE_SINK         (1 << 1)
 
 /**
  * Connection context. */
@@ -57,6 +57,11 @@ struct ba_pcm {
 	/* BlueALSA D-Bus PCM path */
 	char pcm_path[128];
 
+	/* BlueALSA profile type */
+	unsigned int profile;
+	/* available stream modes */
+	unsigned int modes;
+
 	/* PCM stream format */
 	dbus_uint16_t format;
 	/* number of audio channels */
@@ -72,8 +77,6 @@ struct ba_pcm {
 	dbus_uint16_t delay;
 	/* software volume */
 	dbus_bool_t soft_volume;
-	/* feature flags */
-	unsigned int flags;
 
 	/* 16-bit packed PCM volume */
 	union {
@@ -126,7 +129,8 @@ dbus_bool_t bluealsa_dbus_get_pcms(
 dbus_bool_t bluealsa_dbus_get_pcm(
 		struct ba_dbus_ctx *ctx,
 		const bdaddr_t *addr,
-		unsigned int flags,
+		unsigned int profile,
+		unsigned int modes,
 		struct ba_pcm *pcm,
 		DBusError *error);
 


### PR DESCRIPTION
Right now ALSA will be aware of our dB scaling range, so it will be possible to use functions like `snd_ctl_get_dB_range()`.