### PR TITLE
Forward BlueALSA PCM volume to user defined mixer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ unreleased
 - optional support for A2DP FastStream codec (music & voice)
 - connection keep-alive timeout for all BT profiles
 - fix for rapid consecutive SCO link close(2)/connect(2)
+- bluealsa-aplay: forward PCM volume to ALSA mixer element
 
 bluez-alsa v3.1.0 (2021-06-01)
 ==============================

--- a/doc/bluealsa-aplay.1.rst
+++ b/doc/bluealsa-aplay.1.rst
@@ -6,7 +6,7 @@ bluealsa-aplay
 a simple bluealsa player
 ------------------------
 
-:Date: June 2021
+:Date: July 2021
 :Manual section: 1
 :Manual group: General Commands Manual
 :Version: $VERSION$
@@ -84,6 +84,20 @@ OPTIONS
     too fast) or dropped A2DP frames in the **bluealsa(8)** server (if the
     effective rate is too slow). Increase the period time with this option if
     this problem occurs.
+
+-M NAME, --mixer=NAME
+    Select ALSA mixer device to use for controlling audio output mute state
+    and volume level.
+    In order to use this feature, BlueALSA PCM can not use software volume.
+    The default is ``default``.
+
+--mixer-name=NAME
+    Set the name of the mixer element.
+    The default is ``Master``.
+
+--mixer-index=NUM
+    Set the index of the mixer channel.
+    The default is ``0``.
 
 --profile-a2dp
     Use A2DP profile (default).

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -46,6 +46,11 @@
 #define BA_PCM_MODE_SINK             (1 << 1)
 
 /**
+ * Get max volume level for given PCM. */
+#define BA_PCM_VOLUME_MAX(pcm) \
+	((pcm)->transport & BA_PCM_TRANSPORT_MASK_A2DP ? 127 : 15)
+
+/**
  * Connection context. */
 struct ba_dbus_ctx {
 	/* private D-Bus connection */

--- a/utils/aplay/Makefile.am
+++ b/utils/aplay/Makefile.am
@@ -1,5 +1,5 @@
 # BlueALSA - Makefile.am
-# Copyright (c) 2016-2020 Arkadiusz Bokowy
+# Copyright (c) 2016-2021 Arkadiusz Bokowy
 
 if ENABLE_APLAY
 
@@ -9,6 +9,7 @@ bluealsa_aplay_SOURCES = \
 	../../src/shared/dbus-client.c \
 	../../src/shared/ffb.c \
 	../../src/shared/log.c \
+	alsa-mixer.c \
 	alsa-pcm.c \
 	dbus.c \
 	aplay.c

--- a/utils/aplay/alsa-mixer.c
+++ b/utils/aplay/alsa-mixer.c
@@ -1,0 +1,62 @@
+/*
+ * BlueALSA - alsa-mixer.c
+ * Copyright (c) 2016-2021 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#include "alsa-mixer.h"
+
+#include <stdio.h>
+#include <string.h>
+
+int alsa_mixer_open(snd_mixer_t **mixer, snd_mixer_elem_t **elem,
+		const char *dev_name, const char *elem_name, unsigned int elem_idx,
+		char **msg) {
+
+	snd_mixer_t *_mixer = NULL;
+	snd_mixer_elem_t *_elem;
+	char buf[256];
+	int err;
+
+	snd_mixer_selem_id_t *id;
+	snd_mixer_selem_id_alloca(&id);
+	snd_mixer_selem_id_set_name(id, elem_name);
+	snd_mixer_selem_id_set_index(id, elem_idx);
+
+	if ((err = snd_mixer_open(&_mixer, 0)) != 0) {
+		snprintf(buf, sizeof(buf), "Open mixer: %s", snd_strerror(err));
+		goto fail;
+	}
+	if ((err = snd_mixer_attach(_mixer, dev_name)) != 0) {
+		snprintf(buf, sizeof(buf), "Attach mixer: %s", snd_strerror(err));
+		goto fail;
+	}
+	if ((err = snd_mixer_selem_register(_mixer, NULL, NULL)) != 0) {
+		snprintf(buf, sizeof(buf), "Register mixer class: %s", snd_strerror(err));
+		goto fail;
+	}
+	if ((err = snd_mixer_load(_mixer)) != 0) {
+		snprintf(buf, sizeof(buf), "Load mixer elements: %s", snd_strerror(err));
+		goto fail;
+	}
+	if ((_elem = snd_mixer_find_selem(_mixer, id)) == NULL) {
+		snprintf(buf, sizeof(buf), "Mixer element not found");
+		err = -1;
+		goto fail;
+	}
+
+	*mixer = _mixer;
+	*elem = _elem;
+	return 0;
+
+fail:
+	if (_mixer != NULL)
+		snd_mixer_close(_mixer);
+	if (msg != NULL)
+		*msg = strdup(buf);
+	return err;
+}

--- a/utils/aplay/alsa-mixer.h
+++ b/utils/aplay/alsa-mixer.h
@@ -1,0 +1,20 @@
+/*
+ * BlueALSA - alsa-mixer.h
+ * Copyright (c) 2016-2021 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#ifndef BLUEALSA_APLAY_ALSAMIXER_H_
+#define BLUEALSA_APLAY_ALSAMIXER_H_
+
+#include <alsa/asoundlib.h>
+
+int alsa_mixer_open(snd_mixer_t **mixer, snd_mixer_elem_t **elem,
+		const char *dev_name, const char *elem_name, unsigned int elem_idx,
+		char **msg);
+
+#endif

--- a/utils/aplay/dbus.c
+++ b/utils/aplay/dbus.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - dbus.c
- * Copyright (c) 2016-2020 Arkadiusz Bokowy
+ * Copyright (c) 2016-2021 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -61,7 +61,7 @@ int dbus_bluez_get_device(DBusConnection *conn, const char *path,
 		struct bluez_device *dev, DBusError *error) {
 
 	char path_addr[sizeof("00:00:00:00:00:00")] = { 0 };
-	char *tmp;
+	const char *tmp;
 	size_t i;
 
 	memset(dev, 0, sizeof(*dev));
@@ -100,7 +100,6 @@ int dbus_bluez_get_device(DBusConnection *conn, const char *path,
 		dbus_message_iter_recurse(&iter_entry, &iter_entry_val);
 
 		if (strcmp(key, "Adapter") == 0) {
-			const char *tmp;
 			if ((tmp = strrchr(dbus_message_iter_get_basic_string(&iter_entry_val), '/')) != NULL)
 				strncpy(dev->hci_name, tmp + 1, sizeof(dev->hci_name) - 1);
 		}


### PR DESCRIPTION
This commit allows to forward PCM volume to ALSA mixer element, but
only if BlueALSA PCM does not use software volume scaling. In case of
hardware PCM for playback, audio scaling might also be performed by a
hardware component which should be more efficient.