### PR TITLE
calculate scaling factor only when volume changes

### DIFF
--- a/src/a2dp-audio.c
+++ b/src/a2dp-audio.c
@@ -107,9 +107,9 @@ static void ba_transport_pcm_scale(
 
 	/* scaling based on the decibel formula pow(10, dB / 20) */
 	if (!pcm->volume[0].muted)
-		ch1_scale = pow(10, (0.01 * pcm->volume[0].level) / 20);
+		ch1_scale = pcm->volume[0].scaling_factor;
 	if (!pcm->volume[1].muted)
-		ch2_scale = pow(10, (0.01 * pcm->volume[1].level) / 20);
+		ch2_scale = pcm->volume[1].scaling_factor;
 
 	switch (pcm->format) {
 	case BA_TRANSPORT_PCM_FORMAT_S16_2LE:

--- a/src/ba-transport.h
+++ b/src/ba-transport.h
@@ -124,6 +124,7 @@ struct ba_transport_pcm {
 		int level;
 		/* audio signal mute switch */
 		bool muted;
+		double scaling_factor;
 	} volume[2];
 
 	/* data synchronization */

--- a/src/bluez.c
+++ b/src/bluez.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
+#include <math.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
@@ -286,7 +287,9 @@ static void bluez_endpoint_set_configuration(GDBusMethodInvocation *inv) {
 	int level = ba_transport_pcm_volume_bt_to_level(&t->a2dp.pcm, volume);
 	t->a2dp.bluez_dbus_sep_path = dbus_obj->path;
 	t->a2dp.pcm.volume[0].level = level;
+	t->a2dp.pcm.volume[0].scaling_factor = pow(10, (0.01 * level) / 20);
 	t->a2dp.pcm.volume[1].level = level;
+	t->a2dp.pcm.volume[1].scaling_factor = t->a2dp.pcm.volume[0].scaling_factor;
 	t->a2dp.delay = delay;
 
 	debug("%s configured for device %s",
@@ -1120,6 +1123,8 @@ static void bluez_signal_transport_changed(GDBusConnection *conn, const char *se
 			int level = ba_transport_pcm_volume_bt_to_level(&t->a2dp.pcm, volume);
 			debug("Updating A2DP volume: %u [%.2f dB]", volume, 0.01 * level);
 			t->a2dp.pcm.volume[0].level = t->a2dp.pcm.volume[1].level = level;
+			t->a2dp.pcm.volume[0].scaling_factor = pow(10, (0.01 * level) / 20);
+			t->a2dp.pcm.volume[1].scaling_factor = t->a2dp.pcm.volume[0].scaling_factor;
 			bluealsa_dbus_pcm_update(&t->a2dp.pcm, BA_DBUS_PCM_UPDATE_VOLUME);
 		}
 


### PR DESCRIPTION
The A2DP volume scaling factor is currently recalculated on every io event, event though its value is almost always the same. This PR does the calculation only when the volume is changed. The downside is that memory for 2 doubles is required for each PCM (whether SCO or A2DP).