### PR TITLE
bash completion

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ unreleased
 - support for A2DP Sink with LDAC codec if decoder is available
 - use rst2man (docutils) instead of pandoc to build man-pages
 - bluealsa-cli: utility for using D-Bus API from command line
+- bash completion script
 
 bluez-alsa v3.0.0 (2020-09-15)
 ==============================

--- a/configure.ac
+++ b/configure.ac
@@ -230,16 +230,15 @@ AM_COND_IF([ENABLE_MANPAGES], [
 ])
 
 AC_ARG_WITH([bash-completion],
-	AS_HELP_STRING([--with-bash-completion@<:@=DIR@:>@], [install bash completion script in DIR (or the bash completions default directory if not specified)]),
-	[bashcompdir="${withval}"],
-	[]
-)
-AM_CONDITIONAL([WITH_BASH_COMPLETION], [test "x$with_bash_completion" != "x"])
+	AS_HELP_STRING([--with-bash-completion@<:@=DIR@:>@], [install bash completion
+		script in DIR (or the bash completions default directory if not specified)]))
+AM_CONDITIONAL([WITH_BASH_COMPLETION], [
+	test "x$with_bash_completion" != "x" -a "x$with_bash_completion" != "xno"])
 AS_IF([test "x$with_bash_completion" = "xyes"], [
-   PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
-	[bashcompdir=$($PKG_CONFIG --variable=completionsdir bash-completion)],
-	[bashcompdir="$datadir/bash-completion/completions"])
-])
+	PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+		[bashcompdir=$($PKG_CONFIG --variable=completionsdir bash-completion)],
+		[bashcompdir="$datadir/bash-completion/completions"])
+	], [bashcompdir="$with_bash_completion"])
 
 AC_ARG_ENABLE([test],
 	[AS_HELP_STRING([--enable-test], [enable unit test])])

--- a/configure.ac
+++ b/configure.ac
@@ -227,19 +227,16 @@ AM_COND_IF([ENABLE_MANPAGES], [
 	AS_IF([test "x$RST2MAN" = "x"], [AC_MSG_ERROR([[--enable-manpages requires rst2man]])])
 ])
 
-AC_ARG_WITH([bash-completion-dir],
-	AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
-	[Install the bash auto-completion script in this directory. @<:@default=yes@:>@]),
-	[],
-	[with_bash_completion_dir=yes])
-if test "x$with_bash_completion_dir" = "xyes"; then
-    PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
-        [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"],
-        [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])
-else
-    BASH_COMPLETION_DIR="$with_bash_completion_dir"
+AC_ARG_ENABLE([bash-completion],
+	AS_HELP_STRING([--enable-bash-completion@<:@=DIR@:>@], [install bash completion script @<:@default=no@:>@]),
+	[bashcompdir="${enableval}"],
+	[bashcompdir=$($PKG_CONFIG --variable=completionsdir bash-completion)]
+)
+echo "XXX enable_bash_completion = [$enable_bash_completion] XXX"
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION], [test "x$enable_bash_completion" != "x"])
+if test "x$bashcompdir" = "xyes" ; then
+	bashcompdir="$datadir/bash-completion/completions"
 fi
-AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
 
 AC_ARG_ENABLE([test],
 	[AS_HELP_STRING([--enable-test], [enable unit test])])
@@ -288,7 +285,7 @@ AC_DEFINE_UNQUOTED([ALSA_PLUGIN_DIR], "$alsaplugindir", [Directory containing AL
 AC_SUBST([DBUS_CONF_DIR], [$dbusconfdir])
 AC_SUBST([ALSA_CONF_DIR], [$alsaconfdir])
 AC_SUBST([ALSA_PLUGIN_DIR], [$alsaplugindir])
-AC_SUBST([BASH_COMPLETION_DIR])
+AC_SUBST([BASH_COMPLETION_DIR], [$bashcompdir])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,8 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_INSTALL
+AC_PROG_LN_S
+AC_PROG_MKDIR_P
 AM_PROG_AR
 AM_PROG_CC_C_O
 LT_INIT
@@ -227,16 +229,17 @@ AM_COND_IF([ENABLE_MANPAGES], [
 	AS_IF([test "x$RST2MAN" = "x"], [AC_MSG_ERROR([[--enable-manpages requires rst2man]])])
 ])
 
-AC_ARG_ENABLE([bash-completion],
-	AS_HELP_STRING([--enable-bash-completion@<:@=DIR@:>@], [install bash completion script @<:@default=no@:>@]),
-	[bashcompdir="${enableval}"],
-	[bashcompdir=$($PKG_CONFIG --variable=completionsdir bash-completion)]
+AC_ARG_WITH([bash-completion],
+	AS_HELP_STRING([--with-bash-completion@<:@=DIR@:>@], [install bash completion script in DIR (or the bash completions default directory if not specified)]),
+	[bashcompdir="${withval}"],
+	[]
 )
-echo "XXX enable_bash_completion = [$enable_bash_completion] XXX"
-AM_CONDITIONAL([ENABLE_BASH_COMPLETION], [test "x$enable_bash_completion" != "x"])
-if test "x$bashcompdir" = "xyes" ; then
-	bashcompdir="$datadir/bash-completion/completions"
-fi
+AM_CONDITIONAL([WITH_BASH_COMPLETION], [test "x$with_bash_completion" != "x"])
+AS_IF([test "x$with_bash_completion" = "xyes"], [
+   PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+	[bashcompdir=$($PKG_CONFIG --variable=completionsdir bash-completion)],
+	[bashcompdir="$datadir/bash-completion/completions"])
+])
 
 AC_ARG_ENABLE([test],
 	[AS_HELP_STRING([--enable-test], [enable unit test])])

--- a/configure.ac
+++ b/configure.ac
@@ -227,6 +227,20 @@ AM_COND_IF([ENABLE_MANPAGES], [
 	AS_IF([test "x$RST2MAN" = "x"], [AC_MSG_ERROR([[--enable-manpages requires rst2man]])])
 ])
 
+AC_ARG_WITH([bash-completion-dir],
+	AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
+	[Install the bash auto-completion script in this directory. @<:@default=yes@:>@]),
+	[],
+	[with_bash_completion_dir=yes])
+if test "x$with_bash_completion_dir" = "xyes"; then
+    PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+        [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"],
+        [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])
+else
+    BASH_COMPLETION_DIR="$with_bash_completion_dir"
+fi
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
+
 AC_ARG_ENABLE([test],
 	[AS_HELP_STRING([--enable-test], [enable unit test])])
 AM_CONDITIONAL([ENABLE_TEST], [test "x$enable_test" = "xyes"])
@@ -274,6 +288,7 @@ AC_DEFINE_UNQUOTED([ALSA_PLUGIN_DIR], "$alsaplugindir", [Directory containing AL
 AC_SUBST([DBUS_CONF_DIR], [$dbusconfdir])
 AC_SUBST([ALSA_CONF_DIR], [$alsaconfdir])
 AC_SUBST([ALSA_PLUGIN_DIR], [$alsaplugindir])
+AC_SUBST([BASH_COMPLETION_DIR])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/doc/bluealsa-cli.1.rst
+++ b/doc/bluealsa-cli.1.rst
@@ -84,7 +84,7 @@ volume *PCM_PATH* [*N*] [*N*]
 mute *PCM_PATH* [y|n] [y|n]
     If y|n argument(s) are given, set mute component of the volume property of
     the given PCM - 'y' mutes the volume, 'n' unmutes it. The second y|n
-    argument is used for stereo PCMs as described for ``set-volume``.
+    argument is used for stereo PCMs as described for ``volume``.
 
     If no argument is given, print the current mute setting of the given PCM.
 

--- a/doc/bluealsa.8.rst
+++ b/doc/bluealsa.8.rst
@@ -138,7 +138,7 @@ PROFILES
 ========
 
 BlueALSA provides support for Bluetooth Advanced Audio Distribution Profile (A2DP),
-Hands-Free Profile (HFP) and Headset Profile (HFP).
+Hands-Free Profile (HFP) and Headset Profile (HSP).
 A2DP profile is dedicated for streaming music (i.e. stereo, 48 kHz or more sampling
 frequency), while HFP and HSP for two-way voice transmission (mono, 8 kHz or 16 kHz
 sampling frequency).
@@ -169,7 +169,7 @@ FILES
 EXAMPLE
 =======
 
-Emulate Bluetooth headset with A2DP and HFP support:
+Emulate Bluetooth headset with A2DP and HSP support:
 
 ::
 

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -24,7 +24,7 @@ hcitop_LDADD = \
 endif
 
 if ENABLE_BASH_COMPLETION
-bashcompdir = $(BASH_COMPLETION_DIR)
+bashcompdir = @BASH_COMPLETION_DIR@
 bashcomp_DATA = bash-completion/bluealsa
 
 EXTRA_DIST = $(bashcomp_DATA)

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -23,7 +23,7 @@ hcitop_LDADD = \
 	@NCURSES_LIBS@
 endif
 
-if ENABLE_BASH_COMPLETION
+if WITH_BASH_COMPLETION
 bashcompdir = @BASH_COMPLETION_DIR@
 bashcomp_DATA = bash-completion/bluealsa
 
@@ -37,8 +37,9 @@ SYMLINKS = \
 	hcitop
 
 install-data-hook:
+	$(MKDIR_P) $(DESTDIR)$(bashcompdir) && \
 	cd $(DESTDIR)$(bashcompdir) && \
-	for link in $(SYMLINKS); do ln -sf bluealsa $$link; done
+	for link in $(SYMLINKS); do rm -f $$link; $(LN_S) bluealsa $$link; done
 
 uninstall-hook:
 	cd $(DESTDIR)$(bashcompdir) && rm -f $(SYMLINKS)

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -22,3 +22,24 @@ hcitop_LDADD = \
 	@LIBBSD_LIBS@ \
 	@NCURSES_LIBS@
 endif
+
+if ENABLE_BASH_COMPLETION
+bashcompdir = $(BASH_COMPLETION_DIR)
+bashcomp_DATA = bash-completion/bluealsa
+
+EXTRA_DIST = $(bashcomp_DATA)
+
+SYMLINKS = \
+	a2dpconf \
+	bluealsa-aplay \
+	bluealsa-cli \
+	bluealsa-rfcomm \
+	hcitop
+
+install-data-hook:
+	cd $(DESTDIR)$(bashcompdir) && \
+	for link in $(SYMLINKS); do ln -sf bluealsa $$link; done
+
+uninstall-hook:
+	cd $(DESTDIR)$(bashcompdir) && rm -f $(SYMLINKS)
+endif

--- a/utils/bash-completion/bluealsa
+++ b/utils/bash-completion/bluealsa
@@ -170,6 +170,30 @@ _bluealsa() {
 			COMPREPLY=( $(compgen -W "$(_bluealsa_profiles $1)" -- $cur) )
 			return
 			;;
+		--sbc-quality)
+			COMPREPLY=( 0 1 2 3 )
+			return
+			;;
+		--mp3-quality|--mp3-vbr-quality)
+			COMPREPLY=( 0 1 2 3 4 5 6 7 8 9 )
+			return
+			;;
+		--aac-latm-version)
+			COMPREPLY=( 0 1 )
+			return
+			;;
+		--aac-vbr-mode)
+			COMPREPLY=( 0 1 2 3 4 5 )
+			return
+			;;
+		--ldac-eqmid)
+			COMPREPLY=( 0 1 2 )
+			return
+			;;
+		--xapl-resp-name)
+			COMPREPLY=( $(compgen -W "BlueALSA iPhone" -- $cur) )
+			return
+			;;
 		--*)
 			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
 			;;

--- a/utils/bash-completion/bluealsa
+++ b/utils/bash-completion/bluealsa
@@ -171,23 +171,23 @@ _bluealsa() {
 			return
 			;;
 		--sbc-quality)
-			COMPREPLY=( 0 1 2 3 )
+			COMPREPLY=( $(compgen -W "0 1 2 3" -- $cur) )
 			return
 			;;
 		--mp3-quality|--mp3-vbr-quality)
-			COMPREPLY=( 0 1 2 3 4 5 6 7 8 9 )
+			COMPREPLY=( $(compgen -W "0 1 2 3 4 5 6 7 8 9" -- $cur) )
 			return
 			;;
 		--aac-latm-version)
-			COMPREPLY=( 0 1 )
+			COMPREPLY=( $(compgen -W "0 1" -- $cur) )
 			return
 			;;
 		--aac-vbr-mode)
-			COMPREPLY=( 0 1 2 3 4 5 )
+			COMPREPLY=( $(compgen -W "0 1 2 3 4 5" -- $cur) )
 			return
 			;;
 		--ldac-eqmid)
-			COMPREPLY=( 0 1 2 )
+			COMPREPLY=( $(compgen -W "0 1 2" -- $cur) )
 			return
 			;;
 		--xapl-resp-name)

--- a/utils/bash-completion/bluealsa
+++ b/utils/bash-completion/bluealsa
@@ -41,7 +41,7 @@ _bluealsa_valopts() {
 		[[ "$line" =~ --[^=]*= ]] || continue
 		line=${line/,/}
 		[[ "$line" =~ .*[^=]+= ]]
-		printf "%s" "${BASH_REMATCH[0]} "
+		printf "%s" "${BASH_REMATCH[0]//=/}"
 	done
 }
 
@@ -93,8 +93,8 @@ _bluealsa_rfcomm_paths() {
 # @return 0 if no errors found, 1 if dbus check failed
 _bluealsa_util_init() {
 	local valopts=$(_bluealsa_valopts $1)
-	valopts=${valopts//$'\n'/ }
 	service="org.bluealsa"
+	nonopt_offset=0
 	local i
 	for (( i=1; i <= COMP_CWORD; i++ )); do
 		case "${COMP_WORDS[i]}" in
@@ -103,33 +103,33 @@ _bluealsa_util_init() {
 					break
 				elif (( i == COMP_CWORD - 1 )) ; then
 					[[ "${COMP_WORDS[i+1]}" = = ]] && break
-					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
 					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
 					service="org.bluealsa.${COMP_WORDS[i+1]}"
 					break
 				else
 					[[ "${COMP_WORDS[i+1]}" = = ]] && (( i++ ))
-					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
-					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
-					service="org.bluealsa.${COMP_WORDS[i+1]}"
-					(( i++ ))
-					continue
+					if [[ "${COMP_WORDS[i+1]}" ]] ; then
+						(( i++ ))
+						dbus_opt="--dbus=${COMP_WORDS[i]}"
+						service="org.bluealsa.${COMP_WORDS[i]}"
+						continue
+					fi
 				fi
 				;;
 			-B)
 				if (( i == COMP_CWORD )) ; then
 					break
 				elif (( i == COMP_CWORD - 1 )) ; then
-					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
 					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
 					service="org.bluealsa.${COMP_WORDS[i+1]}"
 					break
 				else
-					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
-					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
-					service="org.bluealsa.${COMP_WORDS[i+1]}"
-					(( i++ ))
-					continue
+					if [[ "${COMP_WORDS[i+1]}" ]] ; then
+						(( i++ ))
+						dbus_opt="--dbus=${COMP_WORDS[i]}"
+						service="org.bluealsa.${COMP_WORDS[i]}"
+						continue
+					fi
 				fi
 				;;
 			-*|=)
@@ -137,7 +137,7 @@ _bluealsa_util_init() {
 				;;
 		esac
 
-		[[ "${COMP_WORDS[i-1]}" == = ]] && continue
+		[[ "${COMP_WORDS[i-1]}" == = ]] && (( i < COMP_CWORD )) && continue
 		[[ "$valopts " == *"${COMP_WORDS[i-1]} "* ]] && continue
 
 		nonopt_offset=$i
@@ -218,9 +218,6 @@ _bluealsa_aplay() {
 			COMPREPLY=( $(compgen -W "$list" -- $cur) )
 			return
 			;;
-		--dbus=)
-			return
-			;;
 		--pcm|-D)
 			_have aplay || return
 			COMPREPLY=( $(compgen -W "$(_bluealsa_alsa_pcms)" -- $cur) )
@@ -251,7 +248,8 @@ _bluealsa_aplay() {
 # complete available dbus suffices, command names and pcm paths in addition to options
 _bluealsa_cli() {
 	local cur prev words cword split
-	local dbus_opt nonopt_offset service
+	local dbus_opt service
+	local -i nonopt_offset
 
 	_init_completion -s || return
 
@@ -268,15 +266,14 @@ _bluealsa_cli() {
 			COMPREPLY=( $(compgen -W "$list" -- $cur) )
 			return
 			;;
-		--dbus=)
-			return
-			;;
 		--*)
 			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
 			;;
 	esac
 
 	case "$nonopt_offset" in
+		0) :
+		;;
 		"$COMP_CWORD")
 			# list available commands
 			COMPREPLY=( $(compgen -W "$simple_commands $path_commands" -- "$cur") )
@@ -313,7 +310,7 @@ _bluealsa_cli() {
 			;;
 	esac
 
-	[[ "$nonopt_offset" ]] || _bluealsa_complete_options $1
+	(( nonopt_offset > 0 )) || _bluealsa_complete_options $1
 }
 
 # completion function for bluealsa-rfcomm
@@ -321,7 +318,8 @@ _bluealsa_cli() {
 # requires busctl (part of systemd) to list device paths
 _bluealsa_rfcomm() {
 	local cur prev words cword split
-	local dbus_opt nonopt_offset service
+	local dbus_opt service
+	local -i nonopt_offset
 
 	_init_completion -s || return
 
@@ -333,9 +331,6 @@ _bluealsa_rfcomm() {
 			_have dbus-send || return
 			list=$(_bluealsa_list_dbus_suffices)
 			COMPREPLY=( $(compgen -W "$list" -- $cur) )
-			return
-			;;
-		--dbus=)
 			return
 			;;
 		--*)
@@ -350,7 +345,7 @@ _bluealsa_rfcomm() {
 	fi
 
 	# do not list options if path was found
-	[[ -z "$nonopt_offset" ]] && _bluealsa_complete_options $1
+	(( $nonopt_offset > 0 )) || _bluealsa_complete_options $1
 }
 
 # completion function for a2dpconf and hcitop

--- a/utils/bash-completion/bluealsa
+++ b/utils/bash-completion/bluealsa
@@ -72,10 +72,15 @@ _bluealsa_cli_path_commands() {
 }
 
 # helper function gets ALSA pcms
-_bluealsa_alsa_pcms() {
-	aplay -L 2>/dev/null | while read -r; do
-		[[ "$REPLY" =~ ^[^\ ] ]] && printf "%s\n" "$REPLY "
-	done
+# @param $1 is the current word to match
+_bluealsa_aplay_pcms() {
+	eval local cur="$1"
+	cur="${cur/%\\/\\\\}"
+	while read -r; do
+		[[ "$REPLY" == " "* ]] && continue
+		[[ "$REPLY" == "$cur"* ]] || continue
+		printf "%s\n" "${REPLY// /\\ }"
+	done <<< $(aplay -L 2>/dev/null)
 }
 
 # helper function gets rfcomm dbus paths
@@ -207,7 +212,7 @@ _bluealsa() {
 # - does not complete MAC addresses
 # requires aplay to list ALSA pcms
 _bluealsa_aplay() {
-	local cur prev words cword split list
+	local cur prev words cword split
 
 	_init_completion -s -n : || return
 
@@ -220,7 +225,9 @@ _bluealsa_aplay() {
 			;;
 		--pcm|-D)
 			_have aplay || return
-			COMPREPLY=( $(compgen -W "$(_bluealsa_alsa_pcms)" -- $cur) )
+			local IFS=$'\n'
+			COMPREPLY=( $(_bluealsa_aplay_pcms "$cur" ) )
+
 			# ALSA pcm names can contain '=' and ':', both of which cause
 			# problems for bash completion if it considers them to be word
 			# terminators. So we adjust the list of candidate matches to allow

--- a/utils/bash-completion/bluealsa
+++ b/utils/bash-completion/bluealsa
@@ -1,0 +1,351 @@
+# bash completion for bluez-alsa                            -*- shell-script -*-
+
+# helper function gets available profiles
+# @param $1 the bluealsa executable name
+_bluealsa_profiles() {
+	"$1" --help | while read -r line; do
+		[[ "$line" = "Available BT profiles:" ]] && start=yes && continue
+		[[ "$start" ]] || continue
+		[[ "$line" ]] || break
+		words=($line)
+		printf "%s" "${words[1]} "
+	done
+}
+
+# helper function gets dbus services
+# note that this function does not detect if default service (no suffix) is running.
+_bluealsa_list_dbus_suffices() {
+	dbus-send --system --dest=org.freedesktop.DBus --type=method_call \
+	          --print-reply /org/freedesktop/DBus \
+	          org.freedesktop.DBus.ListNames 2>/dev/null | \
+		while read -r line; do
+			[[ $line =~ org\.bluealsa\.([^'"']+) ]] || continue
+			printf "%s" "${BASH_REMATCH[1]} "
+		done
+}
+
+# helper function gets codecs for given pcm
+# @param $1 the executable name
+# @param $2 dbus option ( --dbus=aaa )
+# @param $3 pcm path
+_bluealsa_codecs() {
+	"$1" $2 codec "$3" | while read -r line; do
+		[[ $line =~ ^Available\ codecs:\ ([^[]+$) ]] && printf "${BASH_REMATCH[1]}"
+	done
+}
+
+# helper function gets options requiring a value ( --opt=val )
+# @param $1 the executable name
+_bluealsa_valopts() {
+	"$1" --help 2>/dev/null | while read -r line; do
+		[[ "$line" =~ --[^=]*= ]] || continue
+		line=${line/,/}
+		[[ "$line" =~ .*[^=]+= ]]
+		printf "%s" "${BASH_REMATCH[0]} "
+	done
+}
+
+# helper function gets bluealsa-cli commands that do not take a pcm-path arg
+# @param $1 the bluealsa-cli executable name
+_bluealsa_cli_simple_commands() {
+	"$1" --help 2>/dev/null | while read -r line; do
+		[[ "$line" = "Commands:" ]] && start=yes && continue
+		[[ "$start" ]] || continue
+		[[ "$line" ]] || break
+		[[ $line =~ \<pcm-path\> ]] && continue
+		words=($line)
+		printf "%s" "${words[0]} "
+	done
+}
+
+# helper function gets bluealsa-cli commands that do take a pcm-path arg
+# @param $1 is the bluealsa-cli executable name
+_bluealsa_cli_path_commands() {
+	"$1" --help 2>/dev/null | while read -r line; do
+		[[ "$line" = "Commands:" ]] && start=yes && continue
+		[[ "$start" ]] || continue
+		[[ "$line" ]] || break
+		[[ $line =~ \<pcm-path\> ]] || continue
+		words=($line)
+		printf "${words[0]} "
+	done
+}
+
+# helper function gets ALSA pcms
+_bluealsa_alsa_pcms() {
+	aplay -L 2>/dev/null | while read -r; do
+		[[ "$REPLY" =~ ^[^\ ] ]] && printf "%s\n" "$REPLY "
+	done
+}
+
+# helper function gets rfcomm dbus paths
+# @param $1 the full bluealsa service name ( org.bluealsa* )
+_bluealsa_rfcomm_paths() {
+	busctl --list tree "$1" 2>/dev/null | while read -r line; do
+		[[ "$line" = /org/bluealsa/hci[0-9]/dev*/rfcomm ]] && printf "%s" "${line/\/rfcomm/}"
+	done
+}
+
+# helper function - Loop through words of command line.
+# puts dbus arg ( --dbus=aaa ) into variable dbus_opt
+# puts service name ( org.bluealsa.aaa ) into variable service
+# puts offset of first non-option argument into variable nonopt_offset
+# @return 0 if no errors found, 1 if dbus check failed
+_bluealsa_util_init() {
+	local valopts=$(_bluealsa_valopts $1)
+	valopts=${valopts//$'\n'/ }
+	service="org.bluealsa"
+	local i
+	for (( i=1; i <= COMP_CWORD; i++ )); do
+		case "${COMP_WORDS[i]}" in
+			--dbus)
+				if (( i == COMP_CWORD )) ; then
+					break
+				elif (( i == COMP_CWORD - 1 )) ; then
+					[[ "${COMP_WORDS[i+1]}" = = ]] && break
+					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
+					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
+					service="org.bluealsa.${COMP_WORDS[i+1]}"
+					break
+				else
+					[[ "${COMP_WORDS[i+1]}" = = ]] && (( i++ ))
+					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
+					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
+					service="org.bluealsa.${COMP_WORDS[i+1]}"
+					(( i++ ))
+					continue
+				fi
+				;;
+			-B)
+				if (( i == COMP_CWORD )) ; then
+					break
+				elif (( i == COMP_CWORD - 1 )) ; then
+					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
+					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
+					service="org.bluealsa.${COMP_WORDS[i+1]}"
+					break
+				else
+					[[ "${COMP_WORDS[i+1]}" == -* ]] && return 1
+					dbus_opt="--dbus=${COMP_WORDS[i+1]}"
+					service="org.bluealsa.${COMP_WORDS[i+1]}"
+					(( i++ ))
+					continue
+				fi
+				;;
+			-*|=)
+				continue
+				;;
+		esac
+
+		[[ "${COMP_WORDS[i-1]}" == = ]] && continue
+		[[ "$valopts " == *"${COMP_WORDS[i-1]} "* ]] && continue
+
+		nonopt_offset=$i
+		break
+
+	done
+
+	return 0
+}
+
+# helper function completes options
+_bluealsa_complete_options() {
+	COMPREPLY=( $(compgen -W "$(_parse_help $1)" -- $cur) )
+    [[ $COMPREPLY == *= ]] && compopt -o nospace
+}
+
+# completion function for bluealsa
+# complete available devices and profiles in addition to options
+_bluealsa() {
+	local cur prev words cword split list
+
+	_init_completion -s || return
+
+	case "$prev" in
+		--device|-i)
+			COMPREPLY=( $(compgen -W "$(ls -I *:* /sys/class/bluetooth)" -- $cur) )
+			return
+			;;
+		--profile|-p)
+			COMPREPLY=( $(compgen -W "$(_bluealsa_profiles $1)" -- $cur) )
+			return
+			;;
+		--*)
+			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
+			;;
+	esac
+
+	_bluealsa_complete_options $1
+}
+
+# completion function for bluealsa-aplay
+# completes available dbus suffices and ALSA pcms in addition to options
+# - does not complete MAC addresses
+# requires aplay to list ALSA pcms
+_bluealsa_aplay() {
+	local cur prev words cword split list
+
+	_init_completion -s -n : || return
+
+	case "$prev" in
+		--dbus|-B)
+			_have dbus-send || return
+			list=$(_bluealsa_list_dbus_suffices)
+			COMPREPLY=( $(compgen -W "$list" -- $cur) )
+			return
+			;;
+		--dbus=)
+			return
+			;;
+		--pcm|-D)
+			_have aplay || return
+			COMPREPLY=( $(compgen -W "$(_bluealsa_alsa_pcms)" -- $cur) )
+			# ALSA pcm names can contain '=' and ':', both of which cause
+			# problems for bash completion if it considers them to be word
+			# terminators. So we adjust the list of candidate matches to allow
+			# for this.
+		    if [[ "$cur" == *=* && "$COMP_WORDBREAKS" == *=* ]]; then
+				# Remove equal-word prefix from COMPREPLY items
+				local equal_prefix=${cur%"${cur##*=}"}
+				local i=${#COMPREPLY[*]}
+				while [[ $((--i)) -ge 0 ]]; do
+				    COMPREPLY[$i]=${COMPREPLY[$i]#"$equal_prefix"}
+				done
+			fi
+			__ltrim_colon_completions "$cur"
+			return
+			;;
+		--*)
+			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
+			;;
+	esac
+
+	_bluealsa_complete_options $1
+}
+
+# completion function for bluealsa-cli
+# complete available dbus suffices, command names and pcm paths in addition to options
+_bluealsa_cli() {
+	local cur prev words cword split
+	local dbus_opt nonopt_offset service
+
+	_init_completion -s || return
+
+	_bluealsa_util_init $1 || return
+
+	# get the command names supported by this version of bluealsa-cli
+	local simple_commands="$(_bluealsa_cli_simple_commands $1)"
+	local path_commands="$(_bluealsa_cli_path_commands $1)"
+
+	case "$prev" in
+		--dbus|-B)
+			_have dbus-send || return
+			list=$(_bluealsa_list_dbus_suffices)
+			COMPREPLY=( $(compgen -W "$list" -- $cur) )
+			return
+			;;
+		--dbus=)
+			return
+			;;
+		--*)
+			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
+			;;
+	esac
+
+	case "$nonopt_offset" in
+		"$COMP_CWORD")
+			# list available commands
+			COMPREPLY=( $(compgen -W "$simple_commands $path_commands" -- "$cur") )
+			return
+			;;
+		$((COMP_CWORD - 1)))
+			# if previous word was command then list available paths
+			if [[ "$path_commands" =~ "$prev" ]]; then
+				COMPREPLY=( $(compgen -W "$("$1" $dbus_opt list-pcms 2>/dev/null)" -- $cur) )
+				return
+			fi
+			;;
+		$((COMP_CWORD - 2)))
+			# Attempt to enumerate command arguments
+			local path="$prev"
+			case ${COMP_WORDS[nonopt_offset]} in
+				codec)
+					COMPREPLY=( $(compgen -W "$(_bluealsa_codecs "$1" "$dbus_opt" "$path")" -- $cur) )
+					return
+					;;
+				mute|soft-volume)
+					COMPREPLY=( $(compgen -W "n y" -- $cur) )
+					return
+					;;
+				*)
+					return
+					;;
+			esac
+			;;
+		$((COMP_CWORD - 3)))
+			[[ ${COMP_WORDS[nonopt_offset]} = mute ]] || return
+			COMPREPLY=( $(compgen -W "n y" -- $cur) )
+			return
+			;;
+	esac
+
+	[[ "$nonopt_offset" ]] || _bluealsa_complete_options $1
+}
+
+# completion function for bluealsa-rfcomm
+# complete available dbus suffices and device paths in addition to options
+# requires busctl (part of systemd) to list device paths
+_bluealsa_rfcomm() {
+	local cur prev words cword split
+	local dbus_opt nonopt_offset service
+
+	_init_completion -s || return
+
+	_bluealsa_util_init $1 || return
+
+	# check for dbus service suffix first
+	case "$prev" in
+		--dbus|-B)
+			_have dbus-send || return
+			list=$(_bluealsa_list_dbus_suffices)
+			COMPREPLY=( $(compgen -W "$list" -- $cur) )
+			return
+			;;
+		--dbus=)
+			return
+			;;
+		--*)
+			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
+			;;
+	esac
+
+	if (( nonopt_offset == COMP_CWORD )) ; then
+		_have busctl || return
+		COMPREPLY=( $(compgen -W "$(_bluealsa_rfcomm_paths $service)" -- $cur) )
+		return
+	fi
+
+	# do not list options if path was found
+	[[ -z "$nonopt_offset" ]] && _bluealsa_complete_options $1
+}
+
+# completion function for a2dpconf and hcitop
+# complete only the options
+_bluealsa_others() {
+	local cur prev words cword split
+	_init_completion -s || return
+	case "$prev" in
+		--*)
+			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
+			;;
+	esac
+	_bluealsa_complete_options $1
+}
+
+complete -F _bluealsa bluealsa
+complete -F _bluealsa_aplay bluealsa-aplay
+complete -F _bluealsa_cli bluealsa-cli
+complete -F _bluealsa_rfcomm bluealsa-rfcomm
+complete -F _bluealsa_others hcitop
+complete -F _bluealsa_others a2dpconf
+# ex: filetype=sh

--- a/utils/bash-completion/bluealsa
+++ b/utils/bash-completion/bluealsa
@@ -225,6 +225,10 @@ _bluealsa_aplay() {
 			;;
 		--pcm|-D)
 			_have aplay || return
+
+			# do not attempt completion on words containing ' or "
+			[[ "$cur" =~ [\'\"] ]] && return
+
 			local IFS=$'\n'
 			COMPREPLY=( $(_bluealsa_aplay_pcms "$cur" ) )
 


### PR DESCRIPTION
A bash completion script for the bluez-alsa programs. This makes bluealsa-cli and bluealsa-rfcomm in particular much easier to use as it saves having to type out object paths.

I also found a couple of typos in the man pages while working n this, so there is also a commit for that too.