### PR TITLE
Use last connected PCM device as default

### DIFF
--- a/doc/bluealsa-api.txt
+++ b/doc/bluealsa-api.txt
@@ -66,6 +66,12 @@ Properties      object Device [readonly]
 
                         BlueZ device object path.
 
+                uint32 Sequence [readonly]
+
+                        This property indicates the sequence in which devices
+                        connected. The larger the value, the later the device
+                        was connected.
+
                 string Transport [readonly]
 
                         Underlying Bluetooth transport type.
@@ -124,12 +130,6 @@ Properties      object Device [readonly]
 
                         Possible A2DP values: 0-127
                         Possible SCO values: 0-15
-
-                uint32 Sequence [readonly]
-
-                        This property indicates the sequence in which devices
-                        connected. The larger the value, the later the device
-                        was connected.
 
 RFCOMM hierarchy
 ================

--- a/doc/bluealsa-api.txt
+++ b/doc/bluealsa-api.txt
@@ -125,6 +125,12 @@ Properties      object Device [readonly]
                         Possible A2DP values: 0-127
                         Possible SCO values: 0-15
 
+                uint32 Sequence [readonly]
+
+                        This property indicates the sequence in which devices
+                        connected. The larger the value, the later the device
+                        was connected.
+
 RFCOMM hierarchy
 ================
 

--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -1,5 +1,6 @@
 # BlueALSA integration setup
 
+defaults.bluealsa.device "00:00:00:00:00:00"
 defaults.bluealsa.profile "a2dp"
 defaults.bluealsa.delay 0
 defaults.bluealsa.battery "yes"

--- a/src/ba-device.c
+++ b/src/ba-device.c
@@ -10,6 +10,7 @@
 
 #include "ba-device.h"
 
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -42,9 +43,7 @@ struct ba_device *ba_device_new(
 	pthread_mutex_init(&d->transports_mutex, NULL);
 	d->transports = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
 
-	pthread_mutex_lock(&config.seq_mutex);
-	d->seq = config.seq++;
-	pthread_mutex_unlock(&config.seq_mutex);
+	d->seq = __atomic_fetch_add(&config.seq, 1, memory_order_relaxed);
 
 	pthread_mutex_lock(&adapter->devices_mutex);
 	g_hash_table_insert(adapter->devices, &d->addr, d);

--- a/src/ba-device.c
+++ b/src/ba-device.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 #include "ba-transport.h"
+#include "bluealsa.h"
 #include "hci.h"
 #include "shared/log.h"
 
@@ -40,6 +41,10 @@ struct ba_device *ba_device_new(
 
 	pthread_mutex_init(&d->transports_mutex, NULL);
 	d->transports = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
+
+	pthread_mutex_lock(&config.seq_mutex);
+	d->seq = config.seq++;
+	pthread_mutex_unlock(&config.seq_mutex);
 
 	pthread_mutex_lock(&adapter->devices_mutex);
 	g_hash_table_insert(adapter->devices, &d->addr, d);

--- a/src/ba-device.h
+++ b/src/ba-device.h
@@ -31,6 +31,9 @@ struct ba_device {
 	/* address of the Bluetooth device */
 	bdaddr_t addr;
 
+	/* connection sequence number */
+	uint32_t seq;
+
 	/* data for D-Bus management */
 	char *ba_dbus_path;
 	char *bluez_dbus_path;

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -117,6 +117,10 @@ static GVariant *ba_variant_new_pcm_volume(const struct ba_transport_pcm *pcm) {
 	return g_variant_new_uint16((ch1 << 8) | (pcm->channels == 1 ? 0 : ch2));
 }
 
+static GVariant *ba_variant_new_pcm_sequence(const struct ba_transport_pcm *pcm) {
+	return g_variant_new_uint32(pcm->t->d->seq);
+}
+
 static void ba_variant_populate_pcm(GVariantBuilder *props, const struct ba_transport_pcm *pcm) {
 	g_variant_builder_init(props, G_VARIANT_TYPE("a{sv}"));
 	g_variant_builder_add(props, "{sv}", "Device", ba_variant_new_device_path(pcm->t->d));
@@ -129,6 +133,7 @@ static void ba_variant_populate_pcm(GVariantBuilder *props, const struct ba_tran
 	g_variant_builder_add(props, "{sv}", "Delay", ba_variant_new_pcm_delay(pcm));
 	g_variant_builder_add(props, "{sv}", "SoftVolume", ba_variant_new_pcm_soft_volume(pcm));
 	g_variant_builder_add(props, "{sv}", "Volume", ba_variant_new_pcm_volume(pcm));
+	g_variant_builder_add(props, "{sv}", "Sequence", ba_variant_new_pcm_sequence(pcm));
 }
 
 static bool ba_variant_populate_sep(GVariantBuilder *props, const struct a2dp_sep *sep) {

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -124,6 +124,7 @@ static GVariant *ba_variant_new_pcm_sequence(const struct ba_transport_pcm *pcm)
 static void ba_variant_populate_pcm(GVariantBuilder *props, const struct ba_transport_pcm *pcm) {
 	g_variant_builder_init(props, G_VARIANT_TYPE("a{sv}"));
 	g_variant_builder_add(props, "{sv}", "Device", ba_variant_new_device_path(pcm->t->d));
+	g_variant_builder_add(props, "{sv}", "Sequence", ba_variant_new_pcm_sequence(pcm));
 	g_variant_builder_add(props, "{sv}", "Transport", ba_variant_new_transport_type(pcm->t));
 	g_variant_builder_add(props, "{sv}", "Mode", ba_variant_new_pcm_mode(pcm));
 	g_variant_builder_add(props, "{sv}", "Format", ba_variant_new_pcm_format(pcm));
@@ -133,7 +134,6 @@ static void ba_variant_populate_pcm(GVariantBuilder *props, const struct ba_tran
 	g_variant_builder_add(props, "{sv}", "Delay", ba_variant_new_pcm_delay(pcm));
 	g_variant_builder_add(props, "{sv}", "SoftVolume", ba_variant_new_pcm_soft_volume(pcm));
 	g_variant_builder_add(props, "{sv}", "Volume", ba_variant_new_pcm_volume(pcm));
-	g_variant_builder_add(props, "{sv}", "Sequence", ba_variant_new_pcm_sequence(pcm));
 }
 
 static bool ba_variant_populate_sep(GVariantBuilder *props, const struct a2dp_sep *sep) {

--- a/src/bluealsa-iface.c
+++ b/src/bluealsa-iface.c
@@ -173,6 +173,10 @@ static const GDBusPropertyInfo bluealsa_iface_pcm_Volume = {
 	NULL
 };
 
+static const GDBusPropertyInfo bluealsa_iface_pcm_Sequence = {
+	-1, "Sequence", "u", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
+};
+
 static const GDBusPropertyInfo *bluealsa_iface_pcm_properties[] = {
 	&bluealsa_iface_pcm_Device,
 	&bluealsa_iface_pcm_Transport,
@@ -184,6 +188,7 @@ static const GDBusPropertyInfo *bluealsa_iface_pcm_properties[] = {
 	&bluealsa_iface_pcm_Delay,
 	&bluealsa_iface_pcm_SoftVolume,
 	&bluealsa_iface_pcm_Volume,
+	&bluealsa_iface_pcm_Sequence,
 	NULL,
 };
 

--- a/src/bluealsa-iface.c
+++ b/src/bluealsa-iface.c
@@ -131,6 +131,10 @@ static const GDBusPropertyInfo bluealsa_iface_pcm_Device = {
 	-1, "Device", "o", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
 };
 
+static const GDBusPropertyInfo bluealsa_iface_pcm_Sequence = {
+	-1, "Sequence", "u", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
+};
+
 static const GDBusPropertyInfo bluealsa_iface_pcm_Transport = {
 	-1, "Transport", "s", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
 };
@@ -173,12 +177,9 @@ static const GDBusPropertyInfo bluealsa_iface_pcm_Volume = {
 	NULL
 };
 
-static const GDBusPropertyInfo bluealsa_iface_pcm_Sequence = {
-	-1, "Sequence", "u", G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
-};
-
 static const GDBusPropertyInfo *bluealsa_iface_pcm_properties[] = {
 	&bluealsa_iface_pcm_Device,
+	&bluealsa_iface_pcm_Sequence,
 	&bluealsa_iface_pcm_Transport,
 	&bluealsa_iface_pcm_Mode,
 	&bluealsa_iface_pcm_Format,
@@ -188,7 +189,6 @@ static const GDBusPropertyInfo *bluealsa_iface_pcm_properties[] = {
 	&bluealsa_iface_pcm_Delay,
 	&bluealsa_iface_pcm_SoftVolume,
 	&bluealsa_iface_pcm_Volume,
-	&bluealsa_iface_pcm_Sequence,
 	NULL,
 };
 

--- a/src/bluealsa.c
+++ b/src/bluealsa.c
@@ -29,7 +29,7 @@ struct ba_config config = {
 	.enable.hsp_ag = true,
 
 	.adapters_mutex = PTHREAD_MUTEX_INITIALIZER,
-	.seq_mutex = PTHREAD_MUTEX_INITIALIZER,
+
 	.seq = 0,
 
 	.null_fd = -1,

--- a/src/bluealsa.c
+++ b/src/bluealsa.c
@@ -29,6 +29,8 @@ struct ba_config config = {
 	.enable.hsp_ag = true,
 
 	.adapters_mutex = PTHREAD_MUTEX_INITIALIZER,
+	.seq_mutex = PTHREAD_MUTEX_INITIALIZER,
+	.seq = 0,
 
 	.null_fd = -1,
 

--- a/src/bluealsa.h
+++ b/src/bluealsa.h
@@ -16,6 +16,7 @@
 #endif
 
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -50,8 +51,7 @@ struct ba_config {
 	GArray *hci_filter;
 
 	/* Device connection sequence number */
-	pthread_mutex_t seq_mutex;
-	uint32_t seq;
+	atomic_uint_fast32_t seq;
 
 	/* used for main thread identification */
 	pthread_t main_thread;

--- a/src/bluealsa.h
+++ b/src/bluealsa.h
@@ -49,6 +49,10 @@ struct ba_config {
 	 * during profile registration. Leave it empty to use any adapter. */
 	GArray *hci_filter;
 
+	/* Device connection sequence number */
+	pthread_mutex_t seq_mutex;
+	uint32_t seq;
+
 	/* used for main thread identification */
 	pthread_t main_thread;
 

--- a/src/shared/dbus-client.c
+++ b/src/shared/dbus-client.c
@@ -10,6 +10,7 @@
 
 #include "shared/dbus-client.h"
 
+#include <stdbool.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -327,7 +328,7 @@ dbus_bool_t bluealsa_dbus_get_pcm(
 	dbus_bool_t rv = TRUE;
 	size_t length = 0;
 	size_t i;
-	dbus_bool_t get_last = bacmp(addr, BDADDR_ANY) == 0;
+	bool get_last = bacmp(addr, BDADDR_ANY) == 0;
 	uint32_t seq = 0;
 	struct ba_pcm *match = NULL;
 

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -107,6 +107,8 @@ struct ba_pcm {
 		dbus_uint16_t raw;
 	} volume;
 
+	/* Connection sequence number */
+	uint32_t sequence;
 };
 
 dbus_bool_t bluealsa_dbus_connection_ctx_init(

--- a/utils/cli/cli.c
+++ b/utils/cli/cli.c
@@ -248,6 +248,7 @@ static int cmd_info(int argc, char *argv[]) {
 	printf("SoftVolume: %s\n", pcm.soft_volume ? "Y" : "N");
 	print_volume(&pcm);
 	print_mute(&pcm);
+	printf("Sequence: %d\n", pcm.sequence);
 
 	if (dbus_error_is_set(&err))
 		warn("Unable to read available codecs: %s", err.message);


### PR DESCRIPTION
Introduces new PCM property "Sequence" and uses this to identify the most recently connected device. Clients can then use 00:00:00:00:00:00 to select that device.