### PR TITLE
ALSA pcm plugin: explicitly set SND_PCM_STATE_DISCONNECTED

### DIFF
--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -406,8 +406,19 @@ static int bluealsa_stop(snd_pcm_ioplug_t *io) {
 
 static snd_pcm_sframes_t bluealsa_pointer(snd_pcm_ioplug_t *io) {
 	struct bluealsa_pcm *pcm = io->private_data;
-	if (pcm->ba_pcm_fd == -1)
+	if (pcm->ba_pcm_fd == -1) {
+		/* ioplug sets the pcm state to SNDRV_PCM_STATE_XRUN when this
+		 * function returns error, so setting the state here has no
+		 * effect - but we do it any way in the hope that one day
+		 * ioplug will acknowledge that pcm devices can disconnect.
+		 * So typically a when an application attempts I/O on a
+		 * disconnected bluealsa pcm it gets EPIPE with state
+		 * SND_PCM_STATE_XRUN, and only later when it attempts to
+		 * recover with snd_pcm_prepare() does it get ENODEV with state
+		 * SND_PCM_STATE_DISCONNECTED */
+		snd_pcm_ioplug_set_state(io, SND_PCM_STATE_DISCONNECTED);
 		return -ENODEV;
+	}
 #ifndef SND_PCM_IOPLUG_FLAG_BOUNDARY_WA
 	if (pcm->io_hw_ptr != -1)
 		return pcm->io_hw_ptr % io->buffer_size;
@@ -493,8 +504,10 @@ static int bluealsa_prepare(snd_pcm_ioplug_t *io) {
 	struct bluealsa_pcm *pcm = io->private_data;
 
 	/* if PCM FIFO is not opened, report it right away */
-	if (pcm->ba_pcm_fd == -1)
+	if (pcm->ba_pcm_fd == -1) {
+		snd_pcm_ioplug_set_state(io, SND_PCM_STATE_DISCONNECTED);
 		return -ENODEV;
+	}
 
 	/* initialize ring buffer */
 	pcm->io_hw_ptr = 0;
@@ -674,8 +687,10 @@ static void bluealsa_dump(snd_pcm_ioplug_t *io, snd_output_t *out) {
 static int bluealsa_delay(snd_pcm_ioplug_t *io, snd_pcm_sframes_t *delayp) {
 	struct bluealsa_pcm *pcm = io->private_data;
 
-	if (pcm->ba_pcm_fd == -1)
+	if (pcm->ba_pcm_fd == -1) {
+		snd_pcm_ioplug_set_state(io, SND_PCM_STATE_DISCONNECTED);
 		return -ENODEV;
+	}
 
 	int ret = 0;
 	*delayp = 0;
@@ -694,9 +709,6 @@ static int bluealsa_delay(snd_pcm_ioplug_t *io, snd_pcm_sframes_t *delayp) {
 			break;
 		case SND_PCM_STATE_SUSPENDED:
 			ret = -ESTRPIPE;
-			break;
-		case SND_PCM_STATE_DISCONNECTED:
-			ret = -ENODEV;
 			break;
 		default:
 			break;
@@ -787,14 +799,12 @@ static int bluealsa_poll_revents(snd_pcm_ioplug_t *io, struct pollfd *pfd,
 			case SND_PCM_STATE_SUSPENDED:
 				*revents |= POLLERR;
 				break;
-			case SND_PCM_STATE_DISCONNECTED:
-				*revents = POLLERR;
-				ret = -ENODEV;
-				break;
 			case SND_PCM_STATE_OPEN:
 				*revents = POLLERR;
 				ret = -EBADF;
 				break;
+			case SND_PCM_STATE_DISCONNECTED:
+				goto fail;
 			default:
 				break;
 		};
@@ -807,6 +817,7 @@ static int bluealsa_poll_revents(snd_pcm_ioplug_t *io, struct pollfd *pfd,
 	return ret;
 
 fail:
+	snd_pcm_ioplug_set_state(io, SND_PCM_STATE_DISCONNECTED);
 	*revents = POLLERR | POLLHUP;
 	return -ENODEV;
 }


### PR DESCRIPTION
ioplug passes ENODEV errors directly through to the client without first
updating its own pcm state, so we are forced to do the upate (as best
we can) from within our plugin. Unfortunately ioplug makes this
impossible from within snd_pcm_writei() and snd_pcm_readi() calls, where
it translates all errors to EPIPE and sets state SND_PCM_STATE_XRUN;
however a subsequent client call to snd_pcm_prepare() will set the
correct state and error code.

Actually many applications appear to ignore both ENODEV and
SND_PCM_STATE_DISCONNECTED, and attempt to restore the PCM anyway,
breaking their audio, typically entering an infinite loop of failed
recovery attempts (they also fail with USB etc soundcards when
unplugged). So in practice this change does not help such applications.
In testing, for example, vlc, mpv and mplayer all fail when a PCM is
disconnected. But at least this change makes it possible for
applications to do the right thing with bluealsa PCMS, whether they take
advantage is up to them.