### PR TITLE
Fix A2DP specification conformance for AAC codec

### DIFF
--- a/doc/bluealsa.8.rst
+++ b/doc/bluealsa.8.rst
@@ -6,7 +6,7 @@ bluealsa
 Bluetooth Audio ALSA Backend
 ----------------------------
 
-:Date: June 2021
+:Date: July 2021
 :Manual section: 8
 :Manual group: System Manager's Manual
 :Version: $VERSION$
@@ -114,6 +114,11 @@ OPTIONS
     This feature increases the audio quality at the cost of increased processing power and overall
     memory consumption.
 
+--aac-bitrate=BPS
+    Set the target bit rate for constant bit rate (CBR) mode or the maximum peak bit rate for
+    variable bit rate (VBR) mode.
+    Default value is **220000** bits per second.
+
 --aac-latm-version=NB
     Select LATM syntax version used for AAC audio transport.
     Default value is **1**.
@@ -123,16 +128,28 @@ OPTIONS
     - **0** - LATM syntax specified by ISO-IEC 14496-3 (2001), should work with all older BT devices
     - **1** - LATM syntax specified by ISO-IEC 14496-3 (2005), should work with newer BT devices
 
---aac-vbr-mode=NB
-    Specifies AAC encoder variable bit rate (VBR) quality, or disables it.
-    The *NB* can be one of:
+--aac-true-bps
+    Enable true "bit per second" bit rate.
 
-    - **0** - disables variable bit rate mode and uses constant bit rate specified by the A2DP AAC configuration
-    - **1** - lowest quality VBR mode (mono: 32 kbps, stereo: 40 kbps)
-    - **2** - low quality VBR mode (mono: 40 kbps, stereo: 64 kbps)
-    - **3** - medium quality VBR mode (mono: 56 kbps, stereo: 96 kbps)
-    - **4** - high quality VBR mode (mono: 72 kbps, stereo: 128 kbps) (**default**)
-    - **5** - highest quality VBR mode (mono: 112 kbps, 192 kbps)
+    A2DP AAC specification requires that for the constant bit rate (CBR) mode every RTP frame has
+    the same bit rate and for the variable bit rate (VBR) mode the maximum peak bit rate limit is
+    also per RTP frame.
+    However, a single RTP frame does not contain a single full second of audio.
+    This option enables true bit rate calculation (per second), which means that per RTP frame bit
+    rate may vary even for CBR mode.
+    This feature is not enabled by default, because it violates A2DP AAC specification.
+    Enabling it should result in an enhanced audio quality, but will for sure produce fragmented
+    RTP frames.
+    If RTP fragmentation is not supported by used A2DP sink device (e.g. headphones) one might
+    hear clearly audible clicks in the playback audio.
+    In such case, please do not enable this option.
+
+--aac-vbr
+    Prefer variable bit rate mode over constant bit rate mode.
+
+    Please note, that this option does not necessarily mean that the variable bit rate (VBR) mode
+    will be used.
+    Used AAC configuration depends on a remote Bluetooth device capabilities.
 
 --ldac-abr
     Enables LDAC adaptive bit rate, which will dynamically adjust encoder quality

--- a/src/a2dp-aac.c
+++ b/src/a2dp-aac.c
@@ -48,6 +48,21 @@ void a2dp_aac_transport_set_codec(struct ba_transport *t) {
 
 }
 
+static unsigned int a2dp_aac_get_fdk_vbr_mode(
+		unsigned int channelmode, unsigned int bitrate) {
+	static const unsigned int modes[][5] = {
+		/* bitrate upper bounds for mono channel mode */
+		{ 32000, 40000, 56000, 72000, 112000 },
+		/* bitrate upper bounds for stereo channel mode */
+		{ 40000, 64000, 96000, 128000, 192000 },
+	};
+	const size_t ch = channelmode == MODE_1 ? 0 : 1;
+	for (size_t i = 0; i < ARRAYSIZE(modes[ch]); i++)
+		if (bitrate <= modes[ch][i])
+			return i + 1;
+	return 5;
+}
+
 static void *a2dp_aac_enc_thread(struct ba_transport_thread *th) {
 
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
@@ -102,6 +117,14 @@ static void *a2dp_aac_enc_thread(struct ba_transport_thread *th) {
 		error("Couldn't set bitrate: %s", aacenc_strerror(err));
 		goto fail_init;
 	}
+#if AACENCODER_LIB_VERSION >= 0x03041600 /* 3.4.22 */
+	if (!config.aac_true_bps) {
+		if ((err = aacEncoder_SetParam(handle, AACENC_PEAK_BITRATE, bitrate)) != AACENC_OK) {
+			error("Couldn't set peak bitrate: %s", aacenc_strerror(err));
+			goto fail_init;
+		}
+	}
+#endif
 	if ((err = aacEncoder_SetParam(handle, AACENC_SAMPLERATE, samplerate)) != AACENC_OK) {
 		error("Couldn't set sampling rate: %s", aacenc_strerror(err));
 		goto fail_init;
@@ -111,8 +134,9 @@ static void *a2dp_aac_enc_thread(struct ba_transport_thread *th) {
 		goto fail_init;
 	}
 	if (configuration->vbr) {
-		if ((err = aacEncoder_SetParam(handle, AACENC_BITRATEMODE, config.aac_vbr_mode)) != AACENC_OK) {
-			error("Couldn't set VBR bitrate mode %u: %s", config.aac_vbr_mode, aacenc_strerror(err));
+		const unsigned int mode = a2dp_aac_get_fdk_vbr_mode(channelmode, bitrate);
+		if ((err = aacEncoder_SetParam(handle, AACENC_BITRATEMODE, mode)) != AACENC_OK) {
+			error("Couldn't set VBR bitrate mode %u: %s", mode, aacenc_strerror(err));
 			goto fail_init;
 		}
 	}

--- a/src/a2dp.h
+++ b/src/a2dp.h
@@ -81,6 +81,8 @@ struct a2dp_sep {
 /* NULL-terminated list of available A2DP codecs */
 extern const struct a2dp_codec *a2dp_codecs[];
 
+int a2dp_codecs_init(void);
+
 const struct a2dp_codec *a2dp_codec_lookup(
 		uint16_t codec_id,
 		enum a2dp_dir dir);

--- a/src/bluealsa.c
+++ b/src/bluealsa.c
@@ -89,11 +89,22 @@ struct ba_config config = {
 	 * b) it generates larger payload. These two reasons are good enough to
 	 * not enable afterburner by default. */
 	.aac_afterburner = false,
+	/* By default try not to not use the VBR mode. Please note, that for A2DP
+	 * sink the VBR mode might still be used if the connection is initialized
+	 * by a remote BT device. */
+	.aac_prefer_vbr = false,
+	/* Do not enable true "bit per second" bit rate by default because it
+	 * violates A2DP AAC specification. */
+	.aac_true_bps = false,
+	/* For CBR mode the 220 kbps bitrate should result in an A2DP frame equal
+	 * to 651 bytes. Such frame size should fit within writing MTU of most BT
+	 * headsets, so it will prevent RTP fragmentation which seems not to be
+	 * supported by every BT headset out there. */
+	.aac_bitrate = 220000,
 	/* Use newer LATM syntax by default. Please note, that some older BT
 	 * devices might not understand this syntax, so for them it might be
 	 * required to use LATM version 0 (ISO-IEC 14496-3 (2001)). */
 	.aac_latm_version = 1,
-	.aac_vbr_mode = 4,
 #endif
 
 #if ENABLE_MP3LAME

--- a/src/bluealsa.h
+++ b/src/bluealsa.h
@@ -117,8 +117,10 @@ struct ba_config {
 
 #if ENABLE_AAC
 	bool aac_afterburner;
-	uint8_t aac_latm_version;
-	uint8_t aac_vbr_mode;
+	bool aac_prefer_vbr;
+	bool aac_true_bps;
+	unsigned int aac_bitrate;
+	unsigned int aac_latm_version;
 #endif
 
 #if ENABLE_MP3LAME

--- a/test/bluealsa-mock.c
+++ b/test/bluealsa-mock.c
@@ -366,13 +366,13 @@ void *mock_service_thread(void *userdata) {
 
 #if ENABLE_APTX
 			g_ptr_array_add(tt, mock_transport_new_a2dp("AA:BB:CC:DD:00:00",
-						BA_TRANSPORT_PROFILE_A2DP_SINK, &a2dp_codec_source_aptx,
+						BA_TRANSPORT_PROFILE_A2DP_SINK, &a2dp_codec_sink_aptx,
 						&config_aptx_44100_stereo));
 #endif
 
 #if ENABLE_APTX_HD
 			g_ptr_array_add(tt, mock_transport_new_a2dp("AA:BB:CC:DD:88:DD",
-						BA_TRANSPORT_PROFILE_A2DP_SINK, &a2dp_codec_source_aptx_hd,
+						BA_TRANSPORT_PROFILE_A2DP_SINK, &a2dp_codec_sink_aptx_hd,
 						&config_aptx_hd_48000_stereo));
 #endif
 
@@ -426,11 +426,14 @@ static void dbus_name_acquired(GDBusConnection *conn, const char *name, void *us
 
 	fprintf(stderr, "BLUEALSA_DBUS_SERVICE_NAME=%s\n", name);
 
-	/* emulate dummy test HCI device */
-	assert((a = ba_adapter_new(0)) != NULL);
-
 	/* do not generate lots of data */
 	config.sbc_quality = SBC_QUALITY_LOW;
+
+	/* initialize codec capabilities */
+	a2dp_codecs_init();
+
+	/* emulate dummy test HCI device */
+	assert((a = ba_adapter_new(0)) != NULL);
 
 	/* run actual BlueALSA mock thread */
 	g_thread_new(NULL, mock_service_thread, loop);


### PR DESCRIPTION
According to the A2DP spec, AAC bitrate field in the A2DP configuration
shall control CBR bit rate and the max peak bit rate for VBR mode. This
commit fixes previous incorrect behavior and removes the --aac-vbr-mode
command line option in favor of --aac-bitrate and --aac-vbr options.

Fixes #474