### PR TITLE
Umute PCM on incoming volume change from BT device

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,7 +1,6 @@
 name: CI - Build and Test
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 jobs:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,7 +1,6 @@
 name: CodeQL Analysis
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 jobs:

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -207,7 +207,7 @@ static void *io_thread(snd_pcm_ioplug_t *io) {
 	/* We update pcm->io_hw_ptr (i.e. the value seen by ioplug) only when
 	 * a period has been completed. We use a temporary copy during the
 	 * transfer procedure. */
-	snd_pcm_uframes_t io_hw_ptr = pcm->io_hw_ptr;
+	snd_pcm_sframes_t io_hw_ptr = pcm->io_hw_ptr;
 
 	debug2("Starting IO loop: %d", pcm->ba_pcm_fd);
 	for (;;) {
@@ -276,7 +276,7 @@ static void *io_thread(snd_pcm_ioplug_t *io) {
 
 		/* Increment the HW pointer (with boundary wrap). */
 		io_hw_ptr += frames;
-		if (io_hw_ptr >= pcm->io_hw_boundary)
+		if ((snd_pcm_uframes_t)io_hw_ptr >= pcm->io_hw_boundary)
 			io_hw_ptr -= pcm->io_hw_boundary;
 
 		ssize_t ret = 0;

--- a/src/ba-rfcomm.c
+++ b/src/ba-rfcomm.c
@@ -363,7 +363,8 @@ static int rfcomm_handler_vgm_set_cb(struct ba_rfcomm *r, const struct bt_at *at
 
 	r->gain_mic = atoi(at->value);
 	int level = ba_transport_pcm_volume_bt_to_level(pcm, r->gain_mic);
-	ba_transport_pcm_volume_set(&pcm->volume[0], &level, NULL);
+	bool muted = false;  /* always unmute when volume changes */
+	ba_transport_pcm_volume_set(&pcm->volume[0], &level, &muted);
 	if (rfcomm_write_at(fd, AT_TYPE_RESP, NULL, "OK") == -1)
 		return -1;
 
@@ -380,7 +381,8 @@ static int rfcomm_handler_vgm_resp_cb(struct ba_rfcomm *r, const struct bt_at *a
 
 	r->gain_mic = atoi(at->value);
 	int level = ba_transport_pcm_volume_bt_to_level(pcm, r->gain_mic);
-	ba_transport_pcm_volume_set(&pcm->volume[0], &level, NULL);
+	bool muted = false;  /* always unmute when volume changes */
+	ba_transport_pcm_volume_set(&pcm->volume[0], &level, &muted);
 
 	bluealsa_dbus_pcm_update(pcm, BA_DBUS_PCM_UPDATE_VOLUME);
 	return 0;
@@ -400,7 +402,8 @@ static int rfcomm_handler_vgs_set_cb(struct ba_rfcomm *r, const struct bt_at *at
 
 	r->gain_spk = atoi(at->value);
 	int level = ba_transport_pcm_volume_bt_to_level(pcm, r->gain_spk);
-	ba_transport_pcm_volume_set(&pcm->volume[0], &level, NULL);
+	bool muted = false;  /* always unmute when volume changes */
+	ba_transport_pcm_volume_set(&pcm->volume[0], &level, &muted);
 	if (rfcomm_write_at(fd, AT_TYPE_RESP, NULL, "OK") == -1)
 		return -1;
 
@@ -417,7 +420,8 @@ static int rfcomm_handler_vgs_resp_cb(struct ba_rfcomm *r, const struct bt_at *a
 
 	r->gain_spk = atoi(at->value);
 	int level = ba_transport_pcm_volume_bt_to_level(pcm, r->gain_spk);
-	ba_transport_pcm_volume_set(&pcm->volume[0], &level, NULL);
+	bool muted = false;  /* always unmute when volume changes */
+	ba_transport_pcm_volume_set(&pcm->volume[0], &level, &muted);
 
 	bluealsa_dbus_pcm_update(pcm, BA_DBUS_PCM_UPDATE_VOLUME);
 	return 0;

--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -1301,7 +1301,7 @@ int ba_transport_pcm_volume_bt_to_level(
 
 int ba_transport_pcm_volume_update(struct ba_transport_pcm *pcm) {
 
-	const struct ba_transport *t = pcm->t;
+	struct ba_transport *t = pcm->t;
 
 	/* In case of A2DP Source or HSP/HFP Audio Gateway skip notifying Bluetooth
 	 * device if we are using software volume control. This will prevent volume
@@ -1312,18 +1312,39 @@ int ba_transport_pcm_volume_update(struct ba_transport_pcm *pcm) {
 
 	if (t->type.profile & BA_TRANSPORT_PROFILE_MASK_A2DP) {
 
-		int level = 0;
-		if (!pcm->volume[0].muted && !pcm->volume[1].muted)
-			level = (pcm->volume[0].level + pcm->volume[1].level) / 2;
+		/* A2DP specification defines volume property as a single value - volume
+		 * for only one channel. For stereo audio we will use an average of left
+		 * and right PCM channels. */
 
-		GError *err = NULL;
-		unsigned int volume = ba_transport_pcm_volume_level_to_bt(pcm, level);
-		g_dbus_set_property(config.dbus, t->bluez_dbus_owner, t->bluez_dbus_path,
-				BLUEZ_IFACE_MEDIA_TRANSPORT, "Volume", g_variant_new_uint16(volume), &err);
+		unsigned int volume = 0;
+		switch (pcm->channels) {
+		case 1:
+			if (!pcm->volume[0].muted)
+				volume = ba_transport_pcm_volume_level_to_bt(pcm,
+						pcm->volume[0].level);
+			break;
+		case 2:
+			if (!pcm->volume[0].muted && !pcm->volume[1].muted)
+				volume = ba_transport_pcm_volume_level_to_bt(pcm,
+						(pcm->volume[0].level + pcm->volume[1].level) / 2);
+			break;
+		default:
+			g_assert_not_reached();
+		}
 
-		if (err != NULL) {
-			warn("Couldn't set BT device volume: %s", err->message);
-			g_error_free(err);
+		/* skip update if nothing has changed */
+		if (volume != t->a2dp.volume) {
+
+			GError *err = NULL;
+			t->a2dp.volume = volume;
+			g_dbus_set_property(config.dbus, t->bluez_dbus_owner, t->bluez_dbus_path,
+					BLUEZ_IFACE_MEDIA_TRANSPORT, "Volume", g_variant_new_uint16(volume), &err);
+
+			if (err != NULL) {
+				warn("Couldn't set BT device volume: %s", err->message);
+				g_error_free(err);
+			}
+
 		}
 
 	}

--- a/src/ba-transport.h
+++ b/src/ba-transport.h
@@ -265,8 +265,10 @@ struct ba_transport {
 			/* selected audio codec configuration */
 			a2dp_t configuration;
 
-			/* delay reported by the AVDTP */
+			/* delay reported by BlueZ */
 			uint16_t delay;
+			/* volume reported by BlueZ */
+			uint16_t volume;
 
 			struct ba_transport_pcm pcm;
 			/* PCM for back-channel stream */


### PR DESCRIPTION
Controlling audio volume should have two parameters: gain level (dB) and mute state. Setting gain level to very low value does not mean that audio will be muted. PCM power will go asymptotically to zero but will never reach it. For zeroing PCM power there should be a mute switch.

Unfortunately, Bluetooth specification (A2DP and HFP/HSP) does not define any standard way of muting audio. Audio volume level is controlled by a property which goes from 0 to MAX (e.g. 15) and by convention audio is muted when the volume level is set to zero.

On the other hand, BlueALSA defines gain level and mute state (like a hardware PCM device). When PCM is muted BlueALSA sets Bluetooth volume level as zero and internally stores PCM volume as muted.

The problem is that once volume is muted by BlueALSA, Bluetooth can not unmute it in any standard way (Bluetooth specification does not define "mute" property). To fix that, from now on, BlueALSA will unmute PCM when there is a signal from a Bluetooth device that the volume should be changed.

Fixes #202