### PR TITLE
Use ALSA config to define PCM initial volume and codec

### DIFF
--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -32,7 +32,7 @@ ctl.bluealsa {
 }
 
 pcm.bluealsa {
-	@args [ DEV PROFILE DELAY SRV ]
+	@args [ DEV PROFILE VOL DELAY SRV ]
 	@args.DEV {
 		type string
 		default {
@@ -46,6 +46,10 @@ pcm.bluealsa {
 			@func refer
 			name defaults.bluealsa.profile
 		}
+	}
+	@args.VOL {
+		type string
+		default ""
 	}
 	@args.DELAY {
 		type integer
@@ -64,10 +68,11 @@ pcm.bluealsa {
 	type plug
 	slave.pcm {
 		type bluealsa
-		service $SRV
 		device $DEV
 		profile $PROFILE
+		volume $VOL
 		delay $DELAY
+		service $SRV
 	}
 	hint {
 		show {

--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -32,7 +32,7 @@ ctl.bluealsa {
 }
 
 pcm.bluealsa {
-	@args [ DEV PROFILE CODEC VOL DELAY SRV ]
+	@args [ DEV PROFILE CODEC VOL SOFTVOL DELAY SRV ]
 	@args.DEV {
 		type string
 		default {
@@ -55,6 +55,14 @@ pcm.bluealsa {
 		type string
 		default ""
 	}
+	@args.SOFTVOL {
+		type string
+		default {
+			@func refer
+			name defaults.bluealsa.softvol
+			default ""
+		}
+	}
 	@args.DELAY {
 		type integer
 		default {
@@ -76,6 +84,7 @@ pcm.bluealsa {
 		profile $PROFILE
 		codec $CODEC
 		volume $VOL
+		softvol $SOFTVOL
 		delay $DELAY
 		service $SRV
 	}

--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -32,7 +32,7 @@ ctl.bluealsa {
 }
 
 pcm.bluealsa {
-	@args [ DEV PROFILE VOL DELAY SRV ]
+	@args [ DEV PROFILE VOL CODEC DELAY SRV ]
 	@args.DEV {
 		type string
 		default {
@@ -48,6 +48,10 @@ pcm.bluealsa {
 		}
 	}
 	@args.VOL {
+		type string
+		default ""
+	}
+	@args.CODEC {
 		type string
 		default ""
 	}
@@ -71,6 +75,7 @@ pcm.bluealsa {
 		device $DEV
 		profile $PROFILE
 		volume $VOL
+		codec $CODEC
 		delay $DELAY
 		service $SRV
 	}

--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -32,7 +32,7 @@ ctl.bluealsa {
 }
 
 pcm.bluealsa {
-	@args [ DEV PROFILE VOL CODEC DELAY SRV ]
+	@args [ DEV PROFILE CODEC VOL DELAY SRV ]
 	@args.DEV {
 		type string
 		default {
@@ -47,11 +47,11 @@ pcm.bluealsa {
 			name defaults.bluealsa.profile
 		}
 	}
-	@args.VOL {
+	@args.CODEC {
 		type string
 		default ""
 	}
-	@args.CODEC {
+	@args.VOL {
 		type string
 		default ""
 	}
@@ -74,8 +74,8 @@ pcm.bluealsa {
 		type bluealsa
 		device $DEV
 		profile $PROFILE
-		volume $VOL
 		codec $CODEC
+		volume $VOL
 		delay $DELAY
 		service $SRV
 	}

--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -6,6 +6,15 @@ defaults.bluealsa.device "00:00:00:00:00:00"
 # Default to A2DP connection because that is what
 # most people want to use - high quality audio.
 defaults.bluealsa.profile "a2dp"
+# By default allow bluealsa to negotiate the "best"
+# codec for each PCM.
+defaults.bluealsa.codec "unchanged"
+# By default do not change the volume or mute state
+# when a PCM is opened.
+defaults.bluealsa.volume "unchanged"
+# By default do not modify the software volume state
+# when a PCM is opened.
+defaults.bluealsa.softvol "unchanged"
 defaults.bluealsa.delay 0
 defaults.bluealsa.battery "yes"
 defaults.bluealsa.service "org.bluealsa"
@@ -49,18 +58,23 @@ pcm.bluealsa {
 	}
 	@args.CODEC {
 		type string
-		default ""
+		default {
+			@func refer
+			name defaults.bluealsa.codec
+		}
 	}
 	@args.VOL {
 		type string
-		default ""
+		default {
+			@func refer
+			name defaults.bluealsa.volume
+		}
 	}
 	@args.SOFTVOL {
 		type string
 		default {
 			@func refer
 			name defaults.bluealsa.softvol
-			default ""
 		}
 	}
 	@args.DELAY {

--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -12,6 +12,7 @@ libasound_module_ctl_bluealsa_la_SOURCES = \
 	bluealsa-ctl.c
 libasound_module_pcm_bluealsa_la_SOURCES = \
 	../shared/dbus-client.c \
+	../shared/hex.c \
 	../shared/log.c \
 	../shared/rt.c \
 	bluealsa-pcm.c

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -144,9 +144,9 @@ static int close_transport(struct bluealsa_pcm *pcm) {
 
 static bool select_codec(struct bluealsa_pcm *pcm, const char *codec, DBusError *err) {
 	bool result = false;
-	uint8_t data[64];
-	uint8_t *data_ptr = NULL;
-	size_t len = 0;
+	uint8_t configuration[64];
+	uint8_t *config_ptr = NULL;
+	size_t config_len = 0;
 
 	if (codec == NULL || *codec == 0)
 		return true;
@@ -158,22 +158,22 @@ static bool select_codec(struct bluealsa_pcm *pcm, const char *codec, DBusError 
 	}
 
 	/* split the given string into name and configuration components */
-	char *config = strchr(name, ':');
-	if (config != NULL) {
-		*config++ = 0;
-		len = strlen(config);
-		if (len > sizeof(data) * 2) {
-			dbus_set_error(err, DBUS_ERROR_FAILED, "Invalid codec configuration: %s", config);
+	char *config_hex = strchr(name, ':');
+	if (config_hex != NULL) {
+		*config_hex++ = 0;
+		config_len = strlen(config_hex);
+		if (config_len > sizeof(configuration) * 2) {
+			dbus_set_error(err, DBUS_ERROR_FAILED, "Invalid codec configuration: %s", config_hex);
 			goto fail;
 		}
-		if ((len = hex2bin(config, data, len)) == -1) {
+		if ((config_len = hex2bin(config_hex, configuration, config_len)) == -1) {
 			dbus_set_error(err, DBUS_ERROR_FAILED, "%s", strerror(errno));
 			goto fail;
 		}
-		data_ptr = data;
+		config_ptr = configuration;
 	}
 
-	if (!bluealsa_dbus_pcm_select_codec(&pcm->dbus_ctx, &pcm->ba_pcm, name, data_ptr, len, err))
+	if (!bluealsa_dbus_pcm_select_codec(&pcm->dbus_ctx, pcm->ba_pcm.pcm_path, name, config_ptr, config_len, err))
 		goto fail;
 
 	result = true;
@@ -509,7 +509,7 @@ static int bluealsa_hw_params(snd_pcm_ioplug_t *io, snd_pcm_hw_params_t *params)
 	pcm->frame_size = (snd_pcm_format_physical_width(io->format) * io->channels) / 8;
 
 	DBusError err = DBUS_ERROR_INIT;
-	if (!bluealsa_dbus_open_pcm(&pcm->dbus_ctx, pcm->ba_pcm.pcm_path,
+	if (!bluealsa_dbus_pcm_open(&pcm->dbus_ctx, pcm->ba_pcm.pcm_path,
 				&pcm->ba_pcm_fd, &pcm->ba_pcm_ctrl_fd, &err)) {
 		debug2("Couldn't open PCM: %s", err.message);
 		dbus_error_free(&err);
@@ -1085,6 +1085,8 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 				SNDERR("Invalid type for %s", id);
 				return -EINVAL;
 			}
+			if (strcmp(codec, "unchanged") == 0)
+				codec = "";
 			continue;
 		}
 		if (strcmp(id, "volume") == 0) {
@@ -1092,11 +1094,15 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 				SNDERR("Invalid type for %s", id);
 				return -EINVAL;
 			}
+			if (strcmp(volume_str, "unchanged") == 0)
+				volume_str = "";
 			continue;
 		}
 		if (strcmp(id, "softvol") == 0) {
 			const char *softvol_str;
 			if (snd_config_get_string(n, &softvol_str) == 0) {
+				if (strcmp(softvol_str, "unchanged") == 0)
+					softvol_str = "";
 				if (strlen(softvol_str) == 0)
 					continue;
 				if ((softvol = snd_config_get_bool(n)) >= 0)
@@ -1222,11 +1228,15 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 		dbus_error_free(&err);
 	}
 
-	if (!update_volume(pcm, volume, mute, &err))
+	if (!update_volume(pcm, volume, mute, &err)) {
 		SNDERR("Couldn't set PCM volume: %s", err.message);
+		dbus_error_free(&err);
+	}
 
-	if (!update_softvol(pcm, softvol, &err))
+	if (!update_softvol(pcm, softvol, &err)) {
 		SNDERR("Couldn't set PCM soft volume property: %s", err.message);
+		dbus_error_free(&err);
+	}
 
 	*pcmp = pcm->io.pcm;
 	return 0;

--- a/src/shared/dbus-client.c
+++ b/src/shared/dbus-client.c
@@ -16,9 +16,56 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
+#include <sys/param.h>
 #include <unistd.h>
 
+#include "a2dp-codecs.h"
+#include "hfp.h"
 #include "shared/defs.h"
+
+struct ba_codec {
+	const char *name;
+	const char **aliases;
+};
+
+static const char *aliases_aptx[] = {
+	"apt-x", NULL
+};
+static const char *aliases_aptx_ad[] = {
+	"apt-x-ad", NULL
+};
+static const char *aliases_aptx_hd[] = {
+	"apt-x-hd", NULL
+};
+static const char *aliases_aptx_ll[] = {
+	"apt-x-ll", NULL
+};
+static const char *aliases_aptx_tws[] = {
+	"apt-x-tws", NULL
+};
+
+static const struct ba_codec codecs[] = {
+	{ "SBC", NULL },
+	{ "MP3", NULL },
+	{ "AAC", NULL },
+	{ "ATRAC", NULL },
+	{ "aptX", aliases_aptx },
+	{ "aptX-AD", aliases_aptx_ad },
+	{ "aptX-HD", aliases_aptx_hd },
+	{ "aptX-LL", aliases_aptx_ll },
+	{ "aptX-TWS", aliases_aptx_tws },
+	{ "FastStream", NULL },
+	{ "LDAC", NULL },
+	{ "LHDC", NULL },
+	{ "LHDC-LL", NULL },
+	{ "LHDC-v1", NULL },
+	{ "samsung-HD", NULL },
+	{ "samsung-SC", NULL },
+	{ "CVSD", NULL },
+	{ "MSBC", NULL },
+};
+
 
 static int path2ba(const char *path, bdaddr_t *ba) {
 
@@ -826,4 +873,95 @@ dbus_bool_t bluealsa_dbus_message_iter_get_pcm_props(
 		struct ba_pcm *pcm) {
 	return bluealsa_dbus_message_iter_dict(iter, error,
 			bluealsa_dbus_message_iter_get_pcm_props_cb, pcm);
+}
+
+static const char *bluealsa_codec_get_canonical_name(const char *name) {
+	int i, ii;
+
+	for (i = 0; i < ARRAYSIZE(codecs); i++) {
+		if (strcasecmp(name, codecs[i].name) == 0)
+			return codecs[i].name;
+		if (codecs[i].aliases != NULL) {
+			for (ii = 0; codecs[i].aliases[ii] != NULL; ii++) {
+				if (strcasecmp(name, codecs[i].aliases[ii]) == 0)
+					return codecs[i].name;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+dbus_bool_t bluealsa_dbus_pcm_select_codec(
+		struct ba_dbus_ctx *ctx,
+		const struct ba_pcm *pcm,
+		const char *codec,
+		const void *configuration,
+		size_t len,
+		DBusError *error) {
+
+	DBusMessage *msg = NULL, *rep = NULL;
+	dbus_bool_t result = FALSE;
+
+	const char *codec_name = bluealsa_codec_get_canonical_name(codec);
+	if (codec_name == NULL) {
+		dbus_set_error(error, DBUS_ERROR_FAILED, "Unknown codec name: %s", codec);
+		goto fail;
+	}
+
+	if ((msg = dbus_message_new_method_call(ctx->ba_service, pcm->pcm_path,
+					BLUEALSA_INTERFACE_PCM, "SelectCodec")) == NULL) {
+		dbus_set_error(error, DBUS_ERROR_NO_MEMORY, NULL);
+		goto fail;
+	}
+
+	DBusMessageIter iter;
+	dbus_message_iter_init_append(msg, &iter);
+
+	if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &codec_name)) {
+		dbus_set_error(error, DBUS_ERROR_NO_MEMORY, NULL);
+		goto fail;
+	}
+
+	DBusMessageIter props;
+	if (!dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "{sv}", &props)) {
+		dbus_set_error(error, DBUS_ERROR_NO_MEMORY, NULL);
+		goto fail;
+	}
+
+	if (configuration != NULL) {
+		const char *property = "Configuration";
+		DBusMessageIter dict;
+		DBusMessageIter config;
+		DBusMessageIter array;
+		const uint8_t *ptr = configuration;
+
+		if (!dbus_message_iter_open_container(&props, DBUS_TYPE_DICT_ENTRY, NULL, &dict) ||
+				!dbus_message_iter_append_basic(&dict, DBUS_TYPE_STRING, &property) ||
+				!dbus_message_iter_open_container(&dict, DBUS_TYPE_VARIANT, "ay", &config) ||
+				!dbus_message_iter_open_container(&config, DBUS_TYPE_ARRAY, "y", &array) ||
+				!dbus_message_iter_append_fixed_array(&array, DBUS_TYPE_BYTE, &ptr, len) ||
+				!dbus_message_iter_close_container(&config, &array) ||
+				!dbus_message_iter_close_container(&dict, &config) ||
+				!dbus_message_iter_close_container(&props, &dict)) {
+			dbus_set_error(error, DBUS_ERROR_NO_MEMORY, NULL);
+			goto fail;
+		}
+	}
+
+	dbus_message_iter_close_container(&iter, &props);
+
+	if ((rep = dbus_connection_send_with_reply_and_block(ctx->conn,
+					msg, DBUS_TIMEOUT_USE_DEFAULT, error)) == NULL) {
+		goto fail;
+	}
+
+	result = TRUE;
+
+fail:
+	if (msg != NULL)
+		dbus_message_unref(msg);
+	if (rep != NULL)
+		dbus_message_unref(rep);
+	return result;
 }

--- a/src/shared/dbus-client.c
+++ b/src/shared/dbus-client.c
@@ -24,46 +24,33 @@
 #include "hfp.h"
 #include "shared/defs.h"
 
-struct ba_codec {
+static const struct {
+	const char *alias;
 	const char *name;
-	const char **aliases;
-};
-
-static const char *aliases_aptx[] = {
-	"apt-x", NULL
-};
-static const char *aliases_aptx_ad[] = {
-	"apt-x-ad", NULL
-};
-static const char *aliases_aptx_hd[] = {
-	"apt-x-hd", NULL
-};
-static const char *aliases_aptx_ll[] = {
-	"apt-x-ll", NULL
-};
-static const char *aliases_aptx_tws[] = {
-	"apt-x-tws", NULL
-};
-
-static const struct ba_codec codecs[] = {
-	{ "SBC", NULL },
-	{ "MP3", NULL },
-	{ "AAC", NULL },
-	{ "ATRAC", NULL },
-	{ "aptX", aliases_aptx },
-	{ "aptX-AD", aliases_aptx_ad },
-	{ "aptX-HD", aliases_aptx_hd },
-	{ "aptX-LL", aliases_aptx_ll },
-	{ "aptX-TWS", aliases_aptx_tws },
-	{ "FastStream", NULL },
-	{ "LDAC", NULL },
-	{ "LHDC", NULL },
-	{ "LHDC-LL", NULL },
-	{ "LHDC-v1", NULL },
-	{ "samsung-HD", NULL },
-	{ "samsung-SC", NULL },
-	{ "CVSD", NULL },
-	{ "MSBC", NULL },
+} codecs[] = {
+	{ "SBC", "SBC" },
+	{ "MP3", "SBC" },
+	{ "AAC", "AAC" },
+	{ "ATRAC", "ATRAC" },
+	{ "aptX", "aptX" },
+	{ "apt-X", "aptX" },
+	{ "aptX-AD", "aptX-AD" },
+	{ "apt-X-AD", "aptX-AD" },
+	{ "aptX-HD", "aptX-HD" },
+	{ "apt-X-HD", "aptX-HD" },
+	{ "aptX-LL", "aptX-LL" },
+	{ "apt-X-LL", "aptX-LL" },
+	{ "aptX-TWS", "aptX-TWS" },
+	{ "apt-X-TWS", "aptX-TWS" },
+	{ "FastStream", "FastStream" },
+	{ "LDAC", "LDAC" },
+	{ "LHDC", "LHDC" },
+	{ "LHDC-LL", "LHDC-LL" },
+	{ "LHDC-v1", "LHDC-v1" },
+	{ "samsung-HD", "samsung-HD" },
+	{ "samsung-SC", "samsung-SC" },
+	{ "CVSD", "CVSD" },
+	{ "MSBC", "MSBC" },
 };
 
 
@@ -105,18 +92,12 @@ static void ba_dbus_watch_toggled(DBusWatch *watch, void *data) {
 	(void)data;
 }
 
-static const char *bluealsa_codec_get_canonical_name(const char *name) {
-	int i, ii;
+static const char *bluealsa_codec_get_canonical_name(const char *alias) {
+	int i;
 
 	for (i = 0; i < ARRAYSIZE(codecs); i++) {
-		if (strcasecmp(name, codecs[i].name) == 0)
+		if (strcasecmp(alias, codecs[i].alias) == 0)
 			return codecs[i].name;
-		if (codecs[i].aliases != NULL) {
-			for (ii = 0; codecs[i].aliases[ii] != NULL; ii++) {
-				if (strcasecmp(name, codecs[i].aliases[ii]) == 0)
-					return codecs[i].name;
-			}
-		}
 	}
 
 	return NULL;

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -236,4 +236,12 @@ dbus_bool_t bluealsa_dbus_message_iter_get_pcm_props(
 		DBusError *error,
 		struct ba_pcm *pcm);
 
+dbus_bool_t bluealsa_dbus_pcm_select_codec(
+		struct ba_dbus_ctx *ctx,
+		const struct ba_pcm *pcm,
+		const char *codec,
+		const void *configuration,
+		size_t len,
+		DBusError *error);
+
 #endif

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -178,11 +178,19 @@ dbus_bool_t bluealsa_dbus_get_pcm(
 		struct ba_pcm *pcm,
 		DBusError *error);
 
-dbus_bool_t bluealsa_dbus_open_pcm(
+dbus_bool_t bluealsa_dbus_pcm_open(
 		struct ba_dbus_ctx *ctx,
 		const char *pcm_path,
 		int *fd_pcm,
 		int *fd_pcm_ctrl,
+		DBusError *error);
+
+dbus_bool_t bluealsa_dbus_pcm_select_codec(
+		struct ba_dbus_ctx *ctx,
+		const char *pcm_path,
+		const char *codec,
+		const void *configuration,
+		size_t len,
 		DBusError *error);
 
 dbus_bool_t bluealsa_dbus_open_rfcomm(
@@ -235,13 +243,5 @@ dbus_bool_t bluealsa_dbus_message_iter_get_pcm_props(
 		DBusMessageIter *iter,
 		DBusError *error,
 		struct ba_pcm *pcm);
-
-dbus_bool_t bluealsa_dbus_pcm_select_codec(
-		struct ba_dbus_ctx *ctx,
-		const struct ba_pcm *pcm,
-		const char *codec,
-		const void *configuration,
-		size_t len,
-		DBusError *error);
 
 #endif

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -437,7 +437,7 @@ static void *pcm_worker_routine(struct pcm_worker *w) {
 	}
 
 	DBusError err = DBUS_ERROR_INIT;
-	if (!bluealsa_dbus_open_pcm(&dbus_ctx, w->ba_pcm.pcm_path,
+	if (!bluealsa_dbus_pcm_open(&dbus_ctx, w->ba_pcm.pcm_path,
 				&w->ba_pcm_fd, &w->ba_pcm_ctrl_fd, &err)) {
 		error("Couldn't open PCM: %s", err.message);
 		dbus_error_free(&err);

--- a/utils/cli/cli.c
+++ b/utils/cli/cli.c
@@ -373,24 +373,24 @@ static int cmd_codec(int argc, char *argv[]) {
 	int result = EXIT_FAILURE;
 	const char *codec = argv[2];
 
-	uint8_t data[64];
-	uint8_t *data_ptr = NULL;
-	size_t len = 0;
+	uint8_t configuration[64];
+	uint8_t *config_ptr = NULL;
+	size_t config_len = 0;
 
 	if (argc == 4) {
-		len = strlen(argv[3]);
-		if (len > sizeof(data) * 2) {
+		config_len = strlen(argv[3]);
+		if (config_len > sizeof(configuration) * 2) {
 			dbus_set_error(&err, DBUS_ERROR_FAILED, "Invalid codec configuration: %s", argv[3]);
 			goto fail;
 		}
-		if ((len = hex2bin(argv[3], data, len)) == -1) {
+		if ((config_len = hex2bin(argv[3], configuration, config_len)) == -1) {
 			dbus_set_error(&err, DBUS_ERROR_FAILED, "%s", strerror(errno));
 			goto fail;
 		}
-		data_ptr = data;
+		config_ptr = configuration;
 	}
 
-	if (!bluealsa_dbus_pcm_select_codec(&dbus_ctx, &pcm, codec, data_ptr, len, &err))
+	if (!bluealsa_dbus_pcm_select_codec(&dbus_ctx, path, codec, config_ptr, config_len, &err))
 		goto fail;
 
 	result = EXIT_SUCCESS;
@@ -559,7 +559,7 @@ static int cmd_open(int argc, char *argv[]) {
 	size_t len = strlen(path);
 
 	DBusError err = DBUS_ERROR_INIT;
-	if (!bluealsa_dbus_open_pcm(&dbus_ctx, path, &fd_pcm, &fd_pcm_ctrl, &err)) {
+	if (!bluealsa_dbus_pcm_open(&dbus_ctx, path, &fd_pcm, &fd_pcm_ctrl, &err)) {
 		cmd_print_error("Cannot open PCM: %s", err.message);
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
I think both these changes are "nice to have" additions rather than essential function. The volume config works well for me, but the codec config is largely untested as I do not have access to suitable devices - it is tested only with A2DP playback with SBC and aptX.