### PR TITLE
ALSA Hook PCM for HFP-AG support

### DIFF
--- a/.github/spellcheck-wordlist.txt
+++ b/.github/spellcheck-wordlist.txt
@@ -48,6 +48,7 @@ TODO
 UI
 UUID
 VBR
+XDG
 XQ
 
 # Proper Names
@@ -78,6 +79,7 @@ endian
 endianness
 enum
 init
+inode
 middleware
 mutex
 natively
@@ -86,6 +88,7 @@ params
 proc
 reinitialization
 scalable
+shm
 signedness
 unexported
 unmute
@@ -105,6 +108,7 @@ asrsync
 autoreconf
 ay
 BAC
+bahfp
 batostr
 battchg
 BCC
@@ -144,6 +148,7 @@ EQMID
 errno
 FB
 ffb
+FIXME
 fs
 GError
 GHashTable
@@ -199,10 +204,13 @@ syslog
 syslogd
 systemd
 TIOCOUTQ
+tmp
+TMPDIR
 TNS
 TWS
 ud
 uint
+unlinked
 VGM
 VGS
 VTable

--- a/src/asound/21-bluealsa-hfp.conf
+++ b/src/asound/21-bluealsa-hfp.conf
@@ -1,0 +1,80 @@
+# BlueALSA HFP-AG helper
+#
+# Sends RFCOMM commands to initiate and terminate a call session with the
+# remote Bluetooth device. For use with devices that only enable HFP audio
+# connections when a call is in progress.
+
+pcm_hook_type.bluealsa_hfp {
+	install "bluealsa_hfp_hook_install"
+	lib "libasound_module_pcm_hooks_bluealsa.so"
+}
+
+pcm.hfp {
+	@args [ DEV CODEC VOL SOFTVOL DELAY SRV ]
+	@args.DEV {
+		type string
+		default {
+			@func refer
+			name defaults.bluealsa.device
+		}
+	}
+	@args.CODEC {
+		type string
+		default {
+			@func refer
+			name defaults.bluealsa.codec
+		}
+	}
+	@args.VOL {
+		type string
+		default {
+			@func refer
+			name defaults.bluealsa.volume
+		}
+	}
+	@args.SOFTVOL {
+		type string
+		default {
+			@func refer
+			name defaults.bluealsa.softvol
+		}
+	}
+	@args.DELAY {
+		type integer
+		default {
+			@func refer
+			name defaults.bluealsa.delay
+		}
+	}
+	@args.SRV {
+		type string
+		default "org.bluealsa"
+	}
+	type hooks
+	slave.pcm {
+		@func concat
+		strings [
+			"bluealsa:PROFILE=sco"
+			",DEV=" $DEV
+			",CODEC=" $CODEC
+			",VOL=" $VOL
+			",SOFTVOL=" $SOFTVOL
+			",DELAY=" $DELAY
+			",SRV=" $SRV
+		]
+	}
+	hooks.0 {
+		type "bluealsa_hfp"
+		hook_args {
+			device $DEV
+			service $SRV
+		}
+	}
+	hint {
+		show {
+			@func refer
+			name defaults.namehint.extended
+		}
+		description "BlueALSA HFP PCM with call enablement"
+	}
+}

--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -1,11 +1,12 @@
 # BlueALSA - Makefile.am
-# Copyright (c) 2016-2021 Arkadiusz Bokowy
+# Copyright (c) 2016-2022 Arkadiusz Bokowy
 
-EXTRA_DIST = 20-bluealsa.conf
+EXTRA_DIST = 20-bluealsa.conf 21-bluealsa-hfp.conf
 
 asound_module_ctl_LTLIBRARIES = libasound_module_ctl_bluealsa.la
 asound_module_pcm_LTLIBRARIES = libasound_module_pcm_bluealsa.la
-asound_module_conf_DATA = 20-bluealsa.conf
+asound_module_hook_LTLIBRARIES = libasound_module_pcm_hooks_bluealsa.la
+asound_module_conf_DATA = 20-bluealsa.conf  21-bluealsa-hfp.conf
 
 libasound_module_ctl_bluealsa_la_SOURCES = \
 	../shared/a2dp-codecs.c \
@@ -18,9 +19,14 @@ libasound_module_pcm_bluealsa_la_SOURCES = \
 	../shared/log.c \
 	../shared/rt.c \
 	bluealsa-pcm.c
-
+libasound_module_pcm_hooks_bluealsa_la_SOURCES = \
+	../shared/a2dp-codecs.c \
+	../shared/dbus-client.c \
+	hfp-session.c \
+	hfp-hook.c
 asound_module_ctldir = @ALSA_PLUGIN_DIR@
 asound_module_pcmdir = @ALSA_PLUGIN_DIR@
+asound_module_hookdir = @ALSA_PLUGIN_DIR@
 asound_module_confdir = @ALSA_CONF_DIR@
 
 AM_CFLAGS = \
@@ -40,3 +46,6 @@ libasound_module_pcm_bluealsa_la_LIBADD = \
 	@ALSA_LIBS@ \
 	@DBUS1_LIBS@ \
 	@LIBUNWIND_LIBS@
+libasound_module_pcm_hooks_bluealsa_la_LIBADD = \
+	@ALSA_LIBS@ \
+	@DBUS1_LIBS@

--- a/src/asound/hfp-hook.c
+++ b/src/asound/hfp-hook.c
@@ -1,0 +1,177 @@
+/*
+ * hfp-hook.c
+ * Copyright (c) 2016-2022 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#define _GNU_SOURCE
+#include <alsa/asoundlib.h>
+#include <alsa/conf.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "hfp-session.h"
+#include "shared/dbus-client.h"
+
+struct bluealsa_hfp {
+	struct ba_dbus_ctx dbus_ctx;
+	struct hfp_session *session;
+	bool session_started;
+};
+
+static int str2bdaddr(const char *str, bdaddr_t *ba) {
+
+	unsigned int x[6];
+	if (sscanf(str, "%x:%x:%x:%x:%x:%x",
+				&x[5], &x[4], &x[3], &x[2], &x[1], &x[0]) != 6)
+		return -1;
+
+	size_t i;
+	for (i = 0; i < 6; i++)
+		ba->b[i] = x[i];
+
+	return 0;
+}
+
+/**
+ * Called when snd_pcm_hw_params() is invoked and only *after* hw_params of the
+ * slave (BlueALSA) PCM has returned success.
+ */
+static int bluealsa_hfp_hw_params(snd_pcm_hook_t *hook) {
+	struct bluealsa_hfp *hfp = (struct bluealsa_hfp*)snd_pcm_hook_get_private(hook);
+
+	if (hfp_session_begin(hfp->session, &hfp->dbus_ctx) == 0) {
+		hfp->session_started = true;
+		/* Delay starting the slave PCM to allow the device to process the
+		 * RFCOMM request.
+		 * FIXME this delay is arbitrary - how to determine needed value? */
+		usleep(500000);
+	}
+
+	return 0;
+}
+
+static int bluealsa_hfp_hw_free(snd_pcm_hook_t *hook) {
+	struct bluealsa_hfp *hfp = (struct bluealsa_hfp*)snd_pcm_hook_get_private(hook);
+
+	if (hfp->session_started) {
+		hfp_session_end(hfp->session, &hfp->dbus_ctx);
+		hfp->session_started = false;
+	}
+	return 0;
+}
+
+static int bluealsa_hfp_close(snd_pcm_hook_t *hook) {
+	struct bluealsa_hfp *hfp = (struct bluealsa_hfp*)snd_pcm_hook_get_private(hook);
+	bluealsa_dbus_connection_ctx_free(&hfp->dbus_ctx);
+	hfp_session_free(hfp->session);
+	free(hfp);
+	snd_pcm_hook_set_private(hook, NULL);
+	return 0;
+}
+
+int bluealsa_hfp_hook_install(snd_pcm_t *pcm, snd_config_t *conf) {
+	const char *device = "00:00:00:00:00:00";
+	const char *service = "org.bluealsa";
+	if (conf) {
+		snd_config_iterator_t i, next;
+		snd_config_for_each(i, next, conf) {
+			snd_config_t *node = snd_config_iterator_entry(i);
+			const char *id;
+			if (snd_config_get_id(node, &id) < 0)
+				continue;
+			if (strcmp(id, "device") == 0) {
+				if (snd_config_get_string(node, &device) < 0) {
+					SNDERR("Invalid type for %s", id);
+					return -EINVAL;
+				}
+				continue;
+			}
+			else if (strcmp(id, "service") == 0) {
+				if (snd_config_get_string(node, &service) < 0) {
+					SNDERR("Invalid type for %s", id);
+					return -EINVAL;
+				}
+				continue;
+			}
+			SNDERR("Unknown field %s", id);
+				return -EINVAL;
+		}
+	}
+
+	struct bluealsa_hfp *hfp = calloc(1, sizeof(struct bluealsa_hfp));
+	if (hfp == NULL)
+		return -ENOMEM;
+
+	int ret = 0;
+	snd_pcm_hook_t *hook_hw_params = NULL;
+	snd_pcm_hook_t *hook_hw_free = NULL;
+	snd_pcm_hook_t *hook_close = NULL;
+
+	bdaddr_t ba_addr;
+	if (device == NULL || str2bdaddr(device, &ba_addr) != 0) {
+		SNDERR("Invalid BT device address: %s", device);
+		ret = EINVAL;
+		goto fail;
+	}
+
+	DBusError err = DBUS_ERROR_INIT;
+
+	if (!bluealsa_dbus_connection_ctx_init(&hfp->dbus_ctx, service, &err)) {
+		SNDERR("Couldn't initialize D-Bus context: %s", err.message);
+		dbus_error_free(&err);
+		return -EIO;
+	}
+
+	struct ba_pcm ba_pcm = { 0 };
+	if (!bluealsa_dbus_get_pcm(&hfp->dbus_ctx,
+				&ba_addr,
+				BA_PCM_TRANSPORT_MASK_SCO,
+				snd_pcm_stream(pcm) == SND_PCM_STREAM_PLAYBACK ? BA_PCM_MODE_SINK : BA_PCM_MODE_SOURCE,
+				&ba_pcm,
+				&err)) {
+		SNDERR("Couldn't get BlueALSA PCM: %s", err.message);
+		ret = -ENODEV;
+		goto fail;
+	}
+
+	if (!(ba_pcm.transport & BA_PCM_TRANSPORT_HFP_AG))
+		goto fail;
+
+	if (hfp_session_init(&hfp->session, ba_pcm.device_path, &ba_pcm.addr) < 0) {
+		SNDERR("Cannot initialize HFP call session");
+		goto fail;
+	}
+
+	if ((ret = snd_pcm_hook_add(&hook_hw_params, pcm, SND_PCM_HOOK_TYPE_HW_PARAMS, bluealsa_hfp_hw_params, hfp)) < 0)
+		goto fail;
+
+	if ((ret = snd_pcm_hook_add(&hook_hw_free, pcm, SND_PCM_HOOK_TYPE_HW_FREE, bluealsa_hfp_hw_free, hfp)) < 0)
+		goto fail;
+
+	if ((ret = snd_pcm_hook_add(&hook_close, pcm, SND_PCM_HOOK_TYPE_CLOSE, bluealsa_hfp_close, hfp)) < 0)
+		goto fail;
+
+	return 0;
+
+fail:
+	bluealsa_dbus_connection_ctx_free(&hfp->dbus_ctx);
+	dbus_error_free(&err);
+	if (hfp->session != NULL)
+		hfp_session_free(hfp->session);
+	free(hfp);
+	if (hook_hw_params)
+		snd_pcm_hook_remove(hook_hw_params);
+	if (hook_hw_free)
+		snd_pcm_hook_remove(hook_hw_free);
+	if (hook_close)
+		snd_pcm_hook_remove(hook_close);
+	return ret;
+}
+SND_DLSYM_BUILD_VERSION(bluealsa_hfp_hook_install, SND_PCM_DLSYM_VERSION);

--- a/src/asound/hfp-session.c
+++ b/src/asound/hfp-session.c
@@ -1,0 +1,280 @@
+/*
+ * hfp-session.c
+ * Copyright (c) 2016-2022 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#define _GNU_SOURCE
+#include <alsa/asoundlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "hfp-session.h"
+
+#define BLUEALSA_HFP_MUTEX_OFFSET 0
+#define BLUEALSA_HFP_FLAG_OFFSET 1
+
+static const char *hfp_ag_transfer_call[] = {
+	"\r\n+CIEV:1,1\r\n",
+	"\r\n+CIEV:5,5\r\n",
+	"\r\n+CIEV:2,1\r\n",
+	NULL,
+};
+
+static const char *hfp_ag_terminate_call[] = {
+	"\r\n+CIEV:2,0\r\n",
+	"\r\n+CIEV:5,0\r\n",
+	"\r\n+CIEV:1,0\r\n",
+	NULL,
+};
+
+static void send_rfcomm_sequence(struct ba_dbus_ctx *dbus_ctx, const char *rfcomm_path, const char **commands) {
+	int rfcomm_fd;
+	DBusError err = DBUS_ERROR_INIT;
+	if (!bluealsa_dbus_open_rfcomm(dbus_ctx, rfcomm_path, &rfcomm_fd, &err)) {
+		SNDERR("Couldn't open RFCOMM: %s", err.message);
+		dbus_error_free(&err);
+		return;
+	}
+
+	int n;
+	for (n = 0; commands[n] != NULL; n++) {
+		ssize_t err = write(rfcomm_fd, commands[n], strlen(commands[n]));
+		if (err < 0 || (size_t)err < strlen(commands[n])) {
+			SNDERR("Couldn't complete RFCOMM sequence: %s", strerror(errno));
+			break;
+		}
+	}
+
+	close(rfcomm_fd);
+}
+
+static const char *get_lock_dir(void) {
+
+	/* If /dev/shm is available and usable, we prefer it. */
+	char *lockdir = "/dev/shm";
+	if (faccessat(0, lockdir, R_OK|W_OK, AT_EACCESS) < 0) {
+		/* FIXME - if the capture and playback applications run in different
+		 * environments they may not see the same lock file. We really need a
+		 * more reliable way of agreeing a path for the lock file when /dev/shm
+		 * cannot be used. */
+		lockdir = getenv("XDG_RUNTIME_DIR");
+		if (lockdir == NULL) {
+			lockdir = getenv("TMPDIR");
+			if (lockdir == NULL)
+				lockdir = "/tmp";
+		}
+	}
+
+	return lockdir;
+}
+
+int hfp_session_init(struct hfp_session **phfp, const char *device_path, const bdaddr_t *addr) {
+
+	if (strlen(device_path) < 37) {
+		SNDERR("Invalid PCM device path");
+		return -EINVAL;
+	}
+
+	struct hfp_session *hfp = malloc(sizeof(struct hfp_session));
+	if (hfp == NULL)
+		return -ENOMEM;
+
+	const char *dev_path = device_path + 11;
+	snprintf(hfp->rfcomm_path, sizeof(hfp->rfcomm_path), "/org/bluealsa/%s/rfcomm", dev_path);
+
+	snprintf(hfp->lock_file, PATH_MAX,
+			"%s/bahfp%.2X%.2X%.2X%.2X%.2X%.2X.lock",
+			get_lock_dir(),
+			addr->b[5], addr->b[4], addr->b[3],
+			addr->b[2], addr->b[1], addr->b[0]);
+
+	hfp->lock_fd = -1;
+
+	*phfp = hfp;
+	return 0;
+}
+
+/**
+ * An HFP device has 2 PCMs (playback and capture), so we need to ensure that
+ * only the first one opened sends the RFCOMM call transfer sequence, and only
+ * the last one closed sends the RFCOMM call termination sequence. We use Linux-
+ * specific Open File Descriptor Locking to achieve this, since neither POSIX
+ * nor BSD file locks have the necessary semantics.
+ */
+int hfp_session_begin(struct hfp_session *hfp, struct ba_dbus_ctx *dbus_ctx) {
+	/* lock to ensure exclusive access to the call session state. */
+	struct flock mutex_lock = {
+		.l_type = F_WRLCK,
+		.l_whence = SEEK_SET,
+		.l_start = BLUEALSA_HFP_MUTEX_OFFSET,
+		.l_len = 1,
+	};
+
+	/* shared lock held continuously while call session is active. */
+	struct flock flag_lock = {
+		.l_type = F_RDLCK,
+		.l_whence = SEEK_SET,
+		.l_start = BLUEALSA_HFP_FLAG_OFFSET,
+		.l_len = 1,
+	};
+
+	int fd;
+	int err;
+	int retries = 5;
+	while (retries > 0) {
+		fd = open(hfp->lock_file, O_CREAT|O_CLOEXEC|O_RDWR, S_IRUSR|S_IWUSR);
+		if (fd == -1) {
+			SNDERR("Unable to open lock file");
+			return -1;
+		}
+
+		/* Wait for mutex lock before managing call state. */
+		err = fcntl(fd, F_OFD_SETLKW, &mutex_lock);
+		if (err == -1) {
+			SNDERR("Unable to set lock file");
+			close(fd);
+			return -1;
+		}
+
+		/* There is a chance that the lock file was unlinked while this process
+		 * was waiting for the mutex. In that case the descriptor fd is no
+		 * longer referring to the correct file. So we check that we are indeed
+		 * looking at the correct file path by comparing the inode of the fd
+		 * with the current inode of the lock file path. */
+		struct stat fd_stat;
+		if (fstat(fd, &fd_stat) < 0) {
+			SNDERR("Unable to check lock file");
+			close(fd);
+			return -1;
+		}
+		struct stat path_stat;
+		err = stat(hfp->lock_file, &path_stat);
+		if (err < 0 && errno != ENOENT) {
+			SNDERR("Unable to check lock file");
+			close(fd);
+			return -1;
+		}
+		if (errno == ENOENT || fd_stat.st_ino != path_stat.st_ino) {
+			/* The lock file we opened is no longer valid - try again. */
+			close(fd);
+			fd = -1;
+			--retries;
+			continue;
+		}
+
+		break;
+	}
+	if (fd == -1) {
+		SNDERR("Unable to open lock file - maximum retries exceeded");
+		return -1;
+	}
+
+	/* set flag lock to indicate we are using this HFP device. */
+	err = fcntl(fd, F_OFD_SETLKW, &flag_lock);
+	if (err == -1) {
+		SNDERR("Unable to set lock file");
+		close(fd);
+		return -1;
+	}
+
+	/* test if we can switch flag to an exclusive lock - if so no other process
+	 * (or thread) is using this HFP device. */
+	flag_lock.l_type = F_WRLCK;
+	err = fcntl(fd, F_OFD_SETLK, &flag_lock);
+	if (err == -1) {
+		if (errno != EAGAIN) {
+			SNDERR("Unable to test lock file");
+			close(fd);
+			return -1;
+		}
+	}
+	else {
+		/* We are (currently) the only process using this HFP device */
+		send_rfcomm_sequence(dbus_ctx, hfp->rfcomm_path, hfp_ag_transfer_call);
+
+		/* Revert the flag to a shared lock */
+		flag_lock.l_type = F_RDLCK;
+		err = fcntl(fd, F_OFD_SETLK, &flag_lock);
+	}
+
+	/* Release the mutex lock. */
+	mutex_lock.l_type = F_UNLCK;
+	err = fcntl(fd, F_OFD_SETLK, &mutex_lock);
+	if (err == -1) {
+		SNDERR("Unable to release lock file");
+		close(fd);
+		return -1;
+	}
+
+	hfp->lock_fd = fd;
+	return 0;
+}
+
+int hfp_session_end(struct hfp_session *hfp, struct ba_dbus_ctx *dbus_ctx) {
+	struct flock mutex_lock = {
+		.l_type = F_WRLCK,
+		.l_whence = SEEK_SET,
+		.l_start = BLUEALSA_HFP_MUTEX_OFFSET,
+		.l_len = 1,
+	};
+
+	struct flock flag_lock = {
+		.l_type = F_WRLCK,
+		.l_whence = SEEK_SET,
+		.l_start = BLUEALSA_HFP_FLAG_OFFSET,
+		.l_len = 1,
+	};
+
+	if (hfp->lock_fd == -1)
+		return 0;
+
+	int ret = 0;
+
+	/* Wait for mutex lock before managing call state. */
+	int err = fcntl(hfp->lock_fd, F_OFD_SETLKW, &mutex_lock);
+	if (err == -1) {
+		SNDERR("Unable to set lock file");
+		ret = -1;
+		goto finish;
+	}
+
+	/* test if we can switch the flag to an exclusive lock - if so no other
+	 * process (or thread) is using this HFP device. */
+	err = fcntl(hfp->lock_fd, F_OFD_SETLK, &flag_lock);
+	if (err == -1) {
+		if (errno != EAGAIN) {
+			SNDERR("Unable to test lock file");
+			ret = -1;
+			goto finish;
+		}
+	}
+	else {
+		/* We are (currently) the only process using this HFP device */
+		send_rfcomm_sequence(dbus_ctx, hfp->rfcomm_path, hfp_ag_terminate_call);
+		unlink(hfp->lock_file);
+	}
+
+finish:
+	/* closing the lock file automatically releases all locks */
+	close(hfp->lock_fd);
+	hfp->lock_fd = -1;
+	return ret;
+}
+
+void hfp_session_free(struct hfp_session *hfp) {
+	if (hfp->lock_fd >= 0) {
+		close(hfp->lock_fd);
+		hfp->lock_fd = -1;
+	}
+	free(hfp);
+}
+

--- a/src/asound/hfp-session.h
+++ b/src/asound/hfp-session.h
@@ -1,0 +1,32 @@
+/*
+ * hfp-session.h
+ * Copyright (c) 2016-2022 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#pragma once
+#ifndef HFP_SESSION_H_
+#define HFP_SESSION_H_
+
+#include <bluetooth/bluetooth.h>
+#include <dbus/dbus.h>
+#include <limits.h>
+
+#include "shared/dbus-client.h"
+
+struct hfp_session {
+	char rfcomm_path[128];
+	char lock_file[PATH_MAX + 1];
+	int lock_fd;
+};
+
+int hfp_session_init(struct hfp_session **phfp, const char *device_path, const bdaddr_t *addr);
+int hfp_session_begin(struct hfp_session *hfp, struct ba_dbus_ctx *dbus_ctx);
+int hfp_session_end(struct hfp_session *hfp, struct ba_dbus_ctx *dbus_ctx);
+void hfp_session_free(struct hfp_session *hfp);
+
+#endif


### PR DESCRIPTION

This is a tentative proposal, more a proof-of-concept or discussion piece than a finished work.

Issue #266 proposes adding basic HFP call transfer and termination support to the BlueALSA server when used with HFP-AG profile. This PR addresses the same requirement by adding optional extra functionality to the ALSA client.

I've deliberately kept the new function completely separated from the existing client by implementing it as a Hook PCM with a distinct config file: this is to simplify discussion, experimentation and initial testing. If the new functionality is deemed desirable then the implememtation could possibly be made more efficient by integrating it with the existing ALSA client.

There's no documentation yet, but the idea is that the user is given a new pre-defined PCM called "hfp" that adds call session handling and is used in much the same way as the `bluealsa` PCM:

```
aplay -D hfp sounds.wav
arecord -D hfp:DEV=XX:XX:XX:XX:XX:XX,CODEC=msbc -r 16000 -c 1 -f s16_le recording.wav
```