### PR TITLE
Volume control on non-decibel mixers

### DIFF
--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -82,6 +82,8 @@ static struct pcm_worker *workers = NULL;
 static size_t workers_count = 0;
 static size_t workers_size = 0;
 
+static long dbscale = 6000;
+
 static bool main_loop_on = true;
 static void main_loop_stop(int sig) {
 	/* Call to this handler restores the default action, so on the
@@ -338,7 +340,7 @@ static int pcm_worker_mixer_volume_sync(
                             	return -1;
 			    }
                             // Convert range to decibel
-                            ch_volume_db= (6000/(v_max-v_min)*(ch_volume-v_min)-6000)/100;
+                            ch_volume_db= (dbscale/(v_max-v_min)*(ch_volume-v_min)-dbscale)/100;
 				
                             debug("Got volume %i (%i-%i), but no db, db_calc=%i", ch_volume,v_min, v_max,ch_volume_db);
                         }
@@ -419,13 +421,13 @@ static int pcm_worker_mixer_volume_update(
                 	return -1;
 		}
 
-		if (db <= -6000) {
+		if (db <= -dbscale) {
 			vol=v_min;
 		} else if (db >= 0) {
 			vol=v_max;
 		} else {
-			// Convert [-6000..0] to [v_min..v_max]
-			vol=v_min+((db+6000)*(v_max-v_min)/6000);
+			// Convert [-dbscale..0] to [v_min..v_max]
+			vol=v_min+((db+dbscale)*(v_max-v_min)/dbscale);
 		}
 
 		if (err=snd_mixer_selem_set_playback_volume_all (elem, vol) != 0) {

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -329,7 +329,7 @@ static int pcm_worker_mixer_volume_sync(
 
 		int err;
 
-		if (err = snd_mixer_selem_get_playback_switch(elem, 0, &ch_switch)) != 0) {
+		if ((err = snd_mixer_selem_get_playback_switch(elem, 0, &ch_switch)) != 0) {
 			ch_switch = 0
 		}
 

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -328,8 +328,12 @@ static int pcm_worker_mixer_volume_sync(
 		long v_max;
 
 		int err;
-		if ((err = snd_mixer_selem_get_playback_dB(elem, 0, &ch_volume_db)) != 0 ||
-				(err = snd_mixer_selem_get_playback_switch(elem, 0, &ch_switch)) != 0) {
+
+		if (err = snd_mixer_selem_get_playback_switch(elem, 0, &ch_switch)) != 0) {
+			ch_switch = 0
+		}
+
+		if ((err = snd_mixer_selem_get_playback_dB(elem, 0, &ch_volume_db)) != 0) {
 
 			if ((err = snd_mixer_selem_get_playback_volume(elem, 0, &ch_volume)) != 0) {
                             error("Couldn't get playback volume: %s", snd_strerror(err));

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -330,7 +330,7 @@ static int pcm_worker_mixer_volume_sync(
 		int err;
 
 		if ((err = snd_mixer_selem_get_playback_switch(elem, 0, &ch_switch)) != 0) {
-			ch_switch = 0
+			ch_switch = 0;
 		}
 
 		if ((err = snd_mixer_selem_get_playback_dB(elem, 0, &ch_volume_db)) != 0) {
@@ -346,7 +346,7 @@ static int pcm_worker_mixer_volume_sync(
                             // Convert range to decibel
                             ch_volume_db= (dbscale/(v_max-v_min)*(ch_volume-v_min)-dbscale)/100;
 				
-                            debug("Got volume %l (%l-%l), but no db, db_calc=%l", ch_volume,v_min, v_max,ch_volume_db);
+                            debug("Got volume %l (%l - %l), but no db, db_calc=%l", ch_volume,v_min, v_max,ch_volume_db);
                         }
 		}
 
@@ -435,7 +435,7 @@ static int pcm_worker_mixer_volume_update(
 		}
 
 		if (err=snd_mixer_selem_set_playback_volume_all (elem, vol) != 0) {
-			error("Couldn't set playback volume %i db/%i: %s", db, vol, snd_strerror(err));
+			error("Couldn't set playback volume %l db/%l: %s", db, vol, snd_strerror(err));
                 	return -1;
 		}
 	}

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -346,7 +346,7 @@ static int pcm_worker_mixer_volume_sync(
                             // Convert range to decibel
                             ch_volume_db= (dbscale/(v_max-v_min)*(ch_volume-v_min)-dbscale)/100;
 				
-                            debug("Got volume %i (%i-%i), but no db, db_calc=%i", ch_volume,v_min, v_max,ch_volume_db);
+                            debug("Got volume %l (%l-%l), but no db, db_calc=%l", ch_volume,v_min, v_max,ch_volume_db);
                         }
 		}
 
@@ -440,7 +440,7 @@ static int pcm_worker_mixer_volume_update(
 		}
 	}
 
-	debug("Set playback volume %i db/%i", db, vol);
+	debug("Set playback volume %l db/%l", db, vol);
 
 	return 0;
 }


### PR DESCRIPTION
This adds volume control if there is no decibel scale available. Not all sound cards offer decibel mixer scale. 
With this patch, the volume control range of the card will be mapped to a -60db..0db range. While it might not be a perfect match as the characteristics of the mixer are unknown it is still better than nothing.