### PR TITLE
Do not enable any BT profile by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,11 @@
 unreleased
 ==========
 
+- changes in command line options (no backward compatibility)
 - optional support for A2DP FastStream codec (music & voice)
 - optional support for A2DP LC3plus codec (music & voice)
 - packet loss concealment (PLC) for HFP with mSBC codec
-- enable/disable BT profiles/codecs via command line options
+- enable/disable BT codecs via command line options
 - allow to select BT transport codec with ALSA configuration
 - allow to set PCM volume properties with ALSA configuration
 - optional single-device mode for ALSA control plug-in

--- a/doc/bluealsa.8.rst
+++ b/doc/bluealsa.8.rst
@@ -14,7 +14,7 @@ Bluetooth Audio ALSA Backend
 SYNOPSIS
 ========
 
-**bluealsa** [*OPTION*] ...
+**bluealsa** -p *PROFILE* [*OPTION*]...
 
 DESCRIPTION
 ===========
@@ -49,13 +49,10 @@ OPTIONS
     Without this option, the default is to use all available HCI devices.
 
 -p NAME, --profile=NAME
-    Enable or disable *NAME* Bluetooth profile.
-    May be given multiple number of times to enable (or disable) multiple profiles.
+    Enable *NAME* Bluetooth profile.
+    May be given multiple number of times to enable multiple profiles.
 
-    In order to disable given profile (remove it from the list of profiles enabled
-    by default), the *NAME* has to be prefixed with **-** (minus) character.
-
-    Without this option, **bluealsa** enables **a2dp-source**, **hfp-ag** and **hsp-ag**.
+    It is mandatory to enabled at leas one Bluetooth profile.
     For the list of supported profiles see the PROFILES_ section below.
 
 -c NAME, --codec=NAME

--- a/doc/bluealsa.8.rst
+++ b/doc/bluealsa.8.rst
@@ -52,7 +52,7 @@ OPTIONS
     Enable *NAME* Bluetooth profile.
     May be given multiple number of times to enable multiple profiles.
 
-    It is mandatory to enabled at leas one Bluetooth profile.
+    It is mandatory to enable at least one Bluetooth profile.
     For the list of supported profiles see the PROFILES_ section below.
 
 -c NAME, --codec=NAME

--- a/misc/systemd/bluealsa.service.in
+++ b/misc/systemd/bluealsa.service.in
@@ -17,7 +17,7 @@ After=bluez.service
 [Service]
 Type=dbus
 BusName=org.bluealsa
-ExecStart=@bindir@/bluealsa
+ExecStart=@bindir@/bluealsa -p a2dp-source -p a2dp-sink
 Restart=on-failure
 
 # Sandboxing

--- a/src/bluealsa-config.c
+++ b/src/bluealsa-config.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - bluealsa-config.c
- * Copyright (c) 2016-2021 Arkadiusz Bokowy
+ * Copyright (c) 2016-2022 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -22,11 +22,6 @@
 
 /* Initialize global configuration variable. */
 struct ba_config config = {
-
-	/* enable output profiles by default */
-	.profile.a2dp_source = true,
-	.profile.hfp_ag = true,
-	.profile.hsp_ag = true,
 
 	.adapters_mutex = PTHREAD_MUTEX_INITIALIZER,
 

--- a/src/main.c
+++ b/src/main.c
@@ -511,7 +511,7 @@ int main(int argc, char **argv) {
 			return EXIT_FAILURE;
 		}
 
-	/* check whether at leas one BT profile was enabled */
+	/* check whether at least one BT profile was enabled */
 	if (!(config.profile.a2dp_source || config.profile.a2dp_sink ||
 				config.profile.hfp_hf || config.profile.hfp_ag ||
 				config.profile.hsp_hs || config.profile.hsp_ag ||

--- a/src/main.c
+++ b/src/main.c
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
 
 		case 'h' /* --help */ :
 			printf("Usage:\n"
-					"  %s [OPTION]...\n"
+					"  %s -p PROFILE [OPTION]...\n"
 					"\nOptions:\n"
 					"  -h, --help\t\t\tprint this help and exit\n"
 					"  -V, --version\t\t\tprint version and exit\n"
@@ -257,10 +257,7 @@ int main(int argc, char **argv) {
 					"  a2dp-source:\t%s\n"
 					"  a2dp-sink:\t%s\n"
 					"  hfp-*:\t%s\n"
-					"\n"
-					"By default only output profiles are enabled, which includes A2DP Source and\n"
-					"HFP/HSP Audio Gateways. If one wants to enable other set of profiles, it is\n"
-					"required to enable (or disable) them using `-p NAME` options.\n",
+					"",
 					argv[0],
 					"v1.3", "v1.3",
 					"v1.7", "v1.7",
@@ -302,16 +299,10 @@ int main(int argc, char **argv) {
 				{ "hsp-ag", &config.profile.hsp_ag },
 			};
 
-			bool enable = true;
 			bool matched = false;
-			if (optarg[0] == '+' || optarg[0] == '-') {
-				enable = optarg[0] == '+' ? true : false;
-				optarg++;
-			}
-
 			for (size_t i = 0; i < ARRAYSIZE(map); i++)
 				if (strcasecmp(optarg, map[i].name) == 0) {
-					*map[i].ptr = enable;
+					*map[i].ptr = true;
 					matched = true;
 					break;
 				}
@@ -519,6 +510,16 @@ int main(int argc, char **argv) {
 			fprintf(stderr, "Try '%s --help' for more information.\n", argv[0]);
 			return EXIT_FAILURE;
 		}
+
+	/* check whether at leas one BT profile was enabled */
+	if (!(config.profile.a2dp_source || config.profile.a2dp_sink ||
+				config.profile.hfp_hf || config.profile.hfp_ag ||
+				config.profile.hsp_hs || config.profile.hsp_ag ||
+				config.profile.hfp_ofono)) {
+		error("It is required to enabled at least one BT profile");
+		fprintf(stderr, "Try '%s --help' for more information.\n", argv[0]);
+		return EXIT_FAILURE;
+	}
 
 #if ENABLE_OFONO
 	if ((config.profile.hfp_ag || config.profile.hfp_hf) && config.profile.hfp_ofono) {


### PR DESCRIPTION
Rationale:

The BlueALSA service can be used in many different ways. There is no
default usage for it. If one wants to build Bluetooth speaker then sink
profiles shall be enabled. If one wants to use Bluetooth headset with a
host on which BlueALSA is running then one shall use source profiles.
Also, there is no default strategy for which sink/source profiles shall
be enabled. We've got A2DP, HSP and HFP.

Taking into account the above statement, it is reasonable to allow a
user to enable suitable set of BT profiles. However, providing a default
set of profiles might be confusing or not easy to use. The first case is
when we provide default profiles, but if user specifies a profile on a
command line, default set of profiles is not used. The latter case is
when we provide a syntax for enabling/disabling BT profiles. Then, in
case when source profiles are enabled by default but user wants only
sink ones, it will be required to manually disable default set, which
is IMHO a configuration burden.

So we have to admit that in case of BT profiles there is no sane
default. From now on BlueALSA will require to specify which profiles
should be enabled.