### PR TITLE
systemd:bluealsa.service.in: change bluez service name

### DIFF
--- a/misc/systemd/bluealsa.service.in
+++ b/misc/systemd/bluealsa.service.in
@@ -2,7 +2,7 @@
 Description=BlueALSA service
 Documentation=man:bluealsa(8)
 Requisite=dbus.service
-After=bluez.service
+After=bluetooth.service
 
 # In order to customize BlueALSA D-Bus service one should create an override
 # for this systemd unit file. Please note, that in the override file one will


### PR DESCRIPTION
On morden popular operating systems like: Debian, Ubuntu, Redhat and
Yocto, the bluez systemd service name is: bluetooth.service.

Let's change the name bluez.service to bluetooth.service to comply with
that.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>