### PR TITLE
Make default description more general

### DIFF
--- a/src/asound/20-bluealsa.conf
+++ b/src/asound/20-bluealsa.conf
@@ -133,6 +133,6 @@ pcm.bluealsa {
 			@func refer
 			name defaults.namehint.extended
 		}
-		description "Bluetooth Audio Hub"
+		description "Bluetooth Audio"
 	}
 }


### PR DESCRIPTION
We are updating the bluez-alsa we ship with OSMC and would like to use your 20-bluealsa.conf without patching.  Confused by the description, though. What is the thinking behind "hub"?