### PR TITLE
Add support for more recent spandsp versions

### DIFF
--- a/src/codec-msbc.h
+++ b/src/codec-msbc.h
@@ -65,7 +65,7 @@ struct esco_msbc {
 	size_t frames;
 
 	/* packet loss concealment */
-	plc_state_t plc;
+	plc_state_t *plc;
 
 	/* Determine whether structure has been initialized. This field is
 	 * used for reinitialization - it makes msbc_init() idempotent. */


### PR DESCRIPTION
The spandsp at https://www.soft-switch.org/ is old and not updated. A fork exist at https://github.com/freeswitch/spandsp and it turns out the old maintainer (Steve Underwood, https://github.com/coppice-git/) contributed to it until 2018:
https://github.com/freeswitch/spandsp/commits?author=coppice-git https://github.com/freeswitch/spandsp/commit/31504fd0c1ab968673234db4cc.patch

Trying to use this version currently fails, because plc_state_t is now a private structure which must be dynamically allocated:

In file included from codec-msbc.c:12:
codec-msbc.h:68:21: error: field 'plc' has incomplete type
   68 |         plc_state_t plc;
      |                     ^~~

Switching to plc_alloc()/plc_free() fixes the problem without breaking compatibility with the old version at www.soft-switch.org