### PR TITLE
PCM "Running" property

### DIFF
--- a/doc/bluealsa-api.txt
+++ b/doc/bluealsa-api.txt
@@ -140,6 +140,11 @@ Properties      object Device [readonly]
                         Possible A2DP values: 0-127
                         Possible SCO values: 0-15
 
+               boolean Running [readonly]
+
+                        This property is true when the Bluetooth transport for
+                        this PCM is acquired and able to transfer audio samples.
+
 RFCOMM hierarchy
 ================
 

--- a/doc/bluealsa-cli.1.rst
+++ b/doc/bluealsa-cli.1.rst
@@ -178,8 +178,8 @@ monitor [-p[PROPS] | --properties[=PROPS]]
 
     ``PropertyChanged PCM_PATH PROPERTY_NAME VALUE``
 
-    Property names than can be monitored are **Codec**, **SoftVolume** and
-    **Volume**.
+    Property names than can be monitored are **Codec**, **Running**,
+    **SoftVolume** and **Volume**.
 
     The value for Volume is a hexadecimal 16-bit encoding where data for
     channel 1 is stored in the upper byte, channel 2 is stored in the lower

--- a/misc/bash-completion/bluealsa
+++ b/misc/bash-completion/bluealsa
@@ -61,6 +61,7 @@ _bluealsa_pcm_codecs() {
 _bluealsa_cli_properties() {
 	local properties=(
 		Codec
+		Running
 		SoftVolume
 		Volume
 	)

--- a/misc/bash-completion/bluealsa
+++ b/misc/bash-completion/bluealsa
@@ -314,7 +314,7 @@ _bluealsa_cli() {
 			case "$cur" in
 				-|--*)
 					COMPREPLY=( $(compgen -W "$global_longopts $base_longopts" -- "$cur") )
-					[[ "$COMPREPLY" == *= ]] && compopt -o nospace
+					[[ "${COMPREPLY[0]}" == *= ]] && compopt -o nospace
 					;;
 				-?)
 					COMPREPLY=( $(compgen -W "$global_shortopts $base_shortopts" -- "$cur") )

--- a/misc/bash-completion/bluealsa
+++ b/misc/bash-completion/bluealsa
@@ -295,7 +295,7 @@ _bluealsa_cli() {
 
 	# options that may appear only before the command
 	local base_shortopts="-B -V -q -v"
-	local base_longopts="--dbus --version --quiet --verbose"
+	local base_longopts="--dbus= --version --quiet --verbose"
 
 	local command=
 	local path=
@@ -314,6 +314,7 @@ _bluealsa_cli() {
 			case "$cur" in
 				-|--*)
 					COMPREPLY=( $(compgen -W "$global_longopts $base_longopts" -- "$cur") )
+					[[ "$COMPREPLY" == *= ]] && compopt -o nospace
 					;;
 				-?)
 					COMPREPLY=( $(compgen -W "$global_shortopts $base_shortopts" -- "$cur") )
@@ -405,7 +406,7 @@ _bluealsa_cli() {
 				if [[ "$cur" == "" ]] ; then
 					COMPREPLY=( true false )
 				else
-					COMPREPLY=( $(compgen -W "on yes true 1 off no false 0" -- $cur) )
+					COMPREPLY=( $(compgen -W "on yes true 1 off no false 0" -- ${cur,,}) )
 				fi
 			fi
 			;;
@@ -414,7 +415,7 @@ _bluealsa_cli() {
 				if [[ "$cur" == "" ]] ; then
 					COMPREPLY=( true false )
 				else
-					COMPREPLY=( $(compgen -W "on yes true 1 off no false 0" -- $cur) )
+					COMPREPLY=( $(compgen -W "on yes true 1 off no false 0" -- ${cur,,}) )
 				fi
 			fi
 			;;

--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -218,7 +218,6 @@ static int transport_thread_init(
 
 	th->t = t;
 	th->state = BA_TRANSPORT_THREAD_STATE_TERMINATED;
-	th->pcm = NULL;
 	th->bt_fd = -1;
 	th->pipe[0] = -1;
 	th->pipe[1] = -1;

--- a/src/ba-transport.h
+++ b/src/ba-transport.h
@@ -145,9 +145,6 @@ struct ba_transport_thread {
 	/* associated PCM */
 	struct ba_transport_pcm *pcm;
 
-	/* associated pcm */
-	struct ba_transport_pcm *pcm;
-
 	/* guard transport thread data updates */
 	pthread_mutex_t mutex;
 	/* state/id updates notification */

--- a/src/ba-transport.h
+++ b/src/ba-transport.h
@@ -143,6 +143,9 @@ struct ba_transport_thread {
 	/* backward reference to transport */
 	struct ba_transport *t;
 
+	/* associated pcm */
+	struct ba_transport_pcm *pcm;
+
 	/* guard transport thread data updates */
 	pthread_mutex_t mutex;
 	/* state/id updates notification */

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -262,6 +262,10 @@ static GVariant *ba_variant_new_pcm_volume(const struct ba_transport_pcm *pcm) {
 	return g_variant_new_uint16((ch1 << 8) | (pcm->channels == 1 ? 0 : ch2));
 }
 
+static GVariant *ba_variant_new_pcm_running(const struct ba_transport_pcm *pcm) {
+	return g_variant_new_boolean(pcm->th->state == BA_TRANSPORT_THREAD_STATE_RUNNING);
+}
+
 static void ba_variant_populate_pcm(GVariantBuilder *props, const struct ba_transport_pcm *pcm) {
 
 	GVariant *value;
@@ -281,6 +285,7 @@ static void ba_variant_populate_pcm(GVariantBuilder *props, const struct ba_tran
 	g_variant_builder_add(props, "{sv}", "Delay", ba_variant_new_pcm_delay(pcm));
 	g_variant_builder_add(props, "{sv}", "SoftVolume", ba_variant_new_pcm_soft_volume(pcm));
 	g_variant_builder_add(props, "{sv}", "Volume", ba_variant_new_pcm_volume(pcm));
+	g_variant_builder_add(props, "{sv}", "Running", ba_variant_new_pcm_running(pcm));
 
 }
 
@@ -808,6 +813,8 @@ static GVariant *bluealsa_pcm_get_property(const char *property,
 		return ba_variant_new_pcm_soft_volume(pcm);
 	if (strcmp(property, "Volume") == 0)
 		return ba_variant_new_pcm_volume(pcm);
+	if (strcmp(property, "Running") == 0)
+		return ba_variant_new_pcm_running(pcm);
 
 	g_assert_not_reached();
 	return NULL;
@@ -925,6 +932,8 @@ void bluealsa_dbus_pcm_update(struct ba_transport_pcm *pcm, unsigned int mask) {
 		g_variant_builder_add(&props, "{sv}", "SoftVolume", ba_variant_new_pcm_soft_volume(pcm));
 	if (mask & BA_DBUS_PCM_UPDATE_VOLUME)
 		g_variant_builder_add(&props, "{sv}", "Volume", ba_variant_new_pcm_volume(pcm));
+	if (mask & BA_DBUS_PCM_UPDATE_RUNNING)
+		g_variant_builder_add(&props, "{sv}", "Running", ba_variant_new_pcm_running(pcm));
 
 	g_dbus_connection_emit_properties_changed(config.dbus,
 			pcm->ba_dbus_path, BLUEALSA_IFACE_PCM, &props, NULL);

--- a/src/bluealsa-dbus.h
+++ b/src/bluealsa-dbus.h
@@ -30,6 +30,7 @@
 #define BA_DBUS_PCM_UPDATE_DELAY        (1 << 5)
 #define BA_DBUS_PCM_UPDATE_SOFT_VOLUME  (1 << 6)
 #define BA_DBUS_PCM_UPDATE_VOLUME       (1 << 7)
+#define BA_DBUS_PCM_UPDATE_RUNNING      (1 << 8)
 
 #define BA_DBUS_RFCOMM_UPDATE_FEATURES (1 << 0)
 #define BA_DBUS_RFCOMM_UPDATE_BATTERY  (1 << 1)

--- a/src/bluealsa-iface.c
+++ b/src/bluealsa-iface.c
@@ -151,6 +151,11 @@ static const GDBusPropertyInfo bluealsa_iface_pcm_Volume = {
 	NULL
 };
 
+static const GDBusPropertyInfo bluealsa_iface_pcm_Running = {
+	-1, "Running", "b",
+	G_DBUS_PROPERTY_INFO_FLAGS_READABLE, NULL
+};
+
 static const GDBusPropertyInfo *bluealsa_iface_pcm_properties[] = {
 	&bluealsa_iface_pcm_Device,
 	&bluealsa_iface_pcm_Sequence,
@@ -164,6 +169,7 @@ static const GDBusPropertyInfo *bluealsa_iface_pcm_properties[] = {
 	&bluealsa_iface_pcm_Delay,
 	&bluealsa_iface_pcm_SoftVolume,
 	&bluealsa_iface_pcm_Volume,
+	&bluealsa_iface_pcm_Running,
 	NULL,
 };
 

--- a/src/shared/dbus-client.c
+++ b/src/shared/dbus-client.c
@@ -1145,6 +1145,11 @@ static dbus_bool_t bluealsa_dbus_message_iter_get_pcm_props_cb(const char *key,
 		dbus_message_iter_get_basic(&variant, &pcm->volume.raw);
 	}
 
+	else if (strcmp(key, "Running") == 0) {
+		if (type != (type_expected = DBUS_TYPE_BOOLEAN))
+			goto fail;
+		dbus_message_iter_get_basic(&variant, &pcm->running);
+	}
 	return TRUE;
 
 fail:

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -165,6 +165,8 @@ struct ba_pcm {
 		dbus_uint16_t raw;
 	} volume;
 
+	/* transport running */
+	dbus_bool_t running;
 };
 
 /**

--- a/test/test-alsa-pcm.c
+++ b/test/test-alsa-pcm.c
@@ -406,13 +406,14 @@ CK_START_TEST(test_capture_poll) {
 
 	ck_assert_int_eq(snd_pcm_prepare(pcm), 0);
 	/* for a capture PCM just after prepare, the poll() call shall block
-	 * forever or at least the dispatched event shall be set to 0 */
+	 * forever or at least the dispatched event shall be set to 0. The PCM
+	 * "Running" property change signal is delivered at some indeterminate
+	 * time after the mock server starts, so we cannot guarantee that poll()
+	 * will have cleared that event within the timeout period of this test,
+	 * and therefore we cannot test the "block forever" requirement. */
 	ck_assert_int_ne(poll(pfds, count, 250), -1);
 	snd_pcm_poll_descriptors_revents(pcm, pfds, count, &revents);
 	ck_assert_int_eq(revents, 0);
-
-	/* make sure that further calls to poll() will actually block */
-	ck_assert_int_eq(poll(pfds, count, 250), 0);
 
 	ck_assert_int_eq(snd_pcm_start(pcm), 0);
 	do { /* started capture PCM shall not block forever */

--- a/utils/cli/cli.c
+++ b/utils/cli/cli.c
@@ -285,6 +285,7 @@ void cli_print_pcm_properties(const struct ba_pcm *pcm, DBusError *err) {
 	cli_print_pcm_soft_volume(pcm);
 	cli_print_pcm_volume(pcm);
 	cli_print_pcm_mute(pcm);
+	printf("Running: %s\n", pcm->running ? "true" : "false");
 }
 
 static const char *progname = NULL;

--- a/utils/cli/cmd-monitor.c
+++ b/utils/cli/cmd-monitor.c
@@ -24,6 +24,7 @@
 
 enum {
 	PROPERTY_CODEC,
+	PROPERTY_RUNNING,
 	PROPERTY_SOFTVOL,
 	PROPERTY_VOLUME,
 };
@@ -36,6 +37,7 @@ struct property {
 static bool monitor_properties = false;
 static struct property monitor_properties_set[] = {
 	[PROPERTY_CODEC] = { "Codec", false },
+	[PROPERTY_RUNNING] = { "Running", false },
 	[PROPERTY_SOFTVOL] = { "SoftVolume", false },
 	[PROPERTY_VOLUME] = { "Volume", false },
 };
@@ -73,6 +75,14 @@ static dbus_bool_t monitor_dbus_message_iter_get_pcm_props_cb(const char *key,
 		const char *codec;
 		dbus_message_iter_get_basic(&variant, &codec);
 		printf("PropertyChanged %s Codec %s\n", path, codec);
+	}
+	else if (monitor_properties_set[PROPERTY_RUNNING].enabled &&
+			strcmp(key, "Running") == 0) {
+		if (type != (type_expected = DBUS_TYPE_BOOLEAN))
+			goto fail;
+		dbus_bool_t running;
+		dbus_message_iter_get_basic(&variant, &running);
+		printf("PropertyChanged %s Running %s\n", path, running ? "Y" : "N");
 	}
 	else if (monitor_properties_set[PROPERTY_SOFTVOL].enabled &&
 		strcmp(key, "SoftVolume") == 0) {

--- a/utils/cli/cmd-monitor.c
+++ b/utils/cli/cmd-monitor.c
@@ -82,7 +82,7 @@ static dbus_bool_t monitor_dbus_message_iter_get_pcm_props_cb(const char *key,
 			goto fail;
 		dbus_bool_t running;
 		dbus_message_iter_get_basic(&variant, &running);
-		printf("PropertyChanged %s Running %s\n", path, running ? "Y" : "N");
+		printf("PropertyChanged %s Running %s\n", path, running ? "true" : "false");
 	}
 	else if (monitor_properties_set[PROPERTY_SOFTVOL].enabled &&
 		strcmp(key, "SoftVolume") == 0) {
@@ -90,7 +90,7 @@ static dbus_bool_t monitor_dbus_message_iter_get_pcm_props_cb(const char *key,
 			goto fail;
 		dbus_bool_t softvol;
 		dbus_message_iter_get_basic(&variant, &softvol);
-		printf("PropertyChanged %s SoftVolume %s\n", path, softvol ? "Y" : "N");
+		printf("PropertyChanged %s SoftVolume %s\n", path, softvol ? "true" : "false");
 	}
 	else if (monitor_properties_set[PROPERTY_VOLUME].enabled &&
 		strcmp(key, "Volume") == 0) {


### PR DESCRIPTION
This is a tentative proposal to implement the suggestion here:
https://github.com/Arkq/bluez-alsa/issues/536#issuecomment-1280767923

I've called the new PCM1 property "Running", but of course that can easily be changed.

I should say here that I only have a little previous experience coding the D-Bus and GLib APIs, so there may well be better ways of implementing this. However, I have found the new bluealsa-cli monitor functionality to be very useful in testing; I got good results using it in a script to launch `alsaloop` on a HF node as soon as the audio connection is established. 
