### PR TITLE
HFP fixes

### DIFF
--- a/doc/bluealsa-plugins.7.rst
+++ b/doc/bluealsa-plugins.7.rst
@@ -530,7 +530,7 @@ When the BlueALSA PCM plugin is used on a source A2DP or gateway HFP/HSP node,
 then **bluealsa(8)** will automatically acquire the transport and begin audio
 transfer when the plugin starts the PCM.
 
-When used on an A2DP sink or HFP/HSP target node then **bluealsa(8)** must wait
+When used on an A2DP sink or HFP/HSP HF/HS node then **bluealsa(8)** must wait
 for the remote device to acquire the transport. During this waiting time the
 PCM plugin behaves as if the device "clock" is stopped, it does not generate
 any poll() events, and the application will be blocked when writing or reading

--- a/doc/bluealsa.8.rst
+++ b/doc/bluealsa.8.rst
@@ -238,7 +238,7 @@ NOTES
 Profiles
 --------
 
-BlueALSA provides support for Bluetooth Advanced Audio Distribution Profile
+**bluealsa** provides support for Bluetooth Advanced Audio Distribution Profile
 (A2DP), Hands-Free Profile (HFP) and Headset Profile (HSP).
 A2DP profile is dedicated for streaming music (i.e., stereo, 48 kHz or more
 sampling frequency), while HFP and HSP for two-way voice transmission (mono, 8
@@ -255,20 +255,32 @@ roles, although it is most common to use it either as a source/gateway:
 
     bluealsa -p a2dp-source -p hfp-ag -p hsp-ag
 
-or as a sink/target, either with oFono:
-
-::
-
-    bluealsa -p a2dp-sink -p hfp-ofono
-
-or without oFono:
+or as a sink/target:
 
 ::
 
     bluealsa -p a2dp-sink -p hfp-hf -p hsp-hs
 
-With A2DP, BlueALSA includes mandatory SBC codec and various optional codecs
-like AAC, aptX, and other.
+or with oFono for HFP support,
+
+source/gateway:
+
+::
+
+    bluealsa -p a2dp-source -p hfp-ofono -p hsp-ag
+
+sink/target:
+
+::
+
+    bluealsa -p a2dp-sink -p hfp-ofono -p hsp-hs
+
+With A2DP, **bluealsa** always includes the mandatory SBC codec and may also
+include various optional codecs like AAC, aptX, and other.
+
+With HFP, **bluealsa** always includes the mandatory CVSD codec and may also
+include the optional mSBC codec.
+
 The full list of available optional codecs, which depends on selected
 compilation options, will be shown with **bluealsa** command-line help message.
 

--- a/src/ofono.h
+++ b/src/ofono.h
@@ -13,6 +13,10 @@
 #ifndef BLUEALSA_OFONO_H_
 #define BLUEALSA_OFONO_H_
 
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
 #include <stdbool.h>
 
 int ofono_init(void);


### PR DESCRIPTION
A collection of changes for HFP, some minor bug fixes, some enhancements. The two oFono related commits need some carefult consideration.

"Improve HFP-HF to support gateways that use oFono" is a work-around for the way that oFono interprets the bluetooth HFP codec connection specification. oFono takes it to mean that the SCO connection must be completed *before* the codec connection is considered complete. It seems neither Android nor IOS have this interpretation, and nor does BueALSA. This commit attempts to allow for BlueALSA to work with both interpretations.

 "Enable oFono AG support for mSBC" is a work-around for the way oFono does codec connection when in AG mode. Its worth noting here that oFono has a bug that causes it to enter a busy loop (100%CPU) when a bluetooth device is disconnected. So to test this it is best to patch the oFono source first. Here is my fix:
```diff
diff --git a/plugins/hfp_ag_bluez5.c b/plugins/hfp_ag_bluez5.c
index 15acf413..e981a9fb 100644
--- a/plugins/hfp_ag_bluez5.c
+++ b/plugins/hfp_ag_bluez5.c
@@ -249,7 +249,7 @@ static DBusMessage *profile_new_connection(DBusConnection *conn,
 
 	fd_dup = dup(fd);
 	io = g_io_channel_unix_new(fd_dup);
-	g_io_add_watch_full(io, G_PRIORITY_DEFAULT, G_IO_HUP, io_hup_cb,
+	g_io_add_watch_full(io, G_PRIORITY_DEFAULT, G_IO_HUP|G_IO_ERR|G_IO_NVAL, io_hup_cb,
 						g_strdup(device), g_free);
 	g_io_channel_unref(io);
 
```