### PR TITLE
Fix msbc on Realtek USB adapters 

### DIFF
--- a/.github/spellcheck-wordlist.txt
+++ b/.github/spellcheck-wordlist.txt
@@ -66,6 +66,7 @@ MPD
 oFono
 PipeWire
 PulseAudio
+Realtek
 UPower
 
 # Technical Words

--- a/doc/bluealsa.8.rst
+++ b/doc/bluealsa.8.rst
@@ -100,6 +100,11 @@ OPTIONS
     It will reduce the gap between playbacks caused by Bluetooth audio
     transport acquisition.
 
+--disable-realtek-usb-fix
+    Since Linux kernel 5.14 Realtek USB adapters have required **bluealsa** to
+    apply a fix for mSBC. This option disables that fix and may be necessary
+    when using an earlier kernel.
+
 --a2dp-force-mono
     Force monophonic sound for A2DP profile.
 

--- a/src/a2dp.c
+++ b/src/a2dp.c
@@ -43,8 +43,8 @@
 #include "a2dp-sbc.h"
 #include "bluealsa-config.h"
 #include "codec-sbc.h"
-#include "hci.h"
 #include "shared/a2dp-codecs.h"
+#include "shared/bluetooth.h"
 #include "shared/log.h"
 
 struct a2dp_codec * const a2dp_codecs[] = {

--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -887,7 +887,7 @@ static int transport_acquire_bt_sco(struct ba_transport *t) {
 
 	debug("New SCO link: %s: %d", batostr_(&d->addr), fd);
 
-	t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, d->a->hci.type);
+	t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, d->a);
 	t->bt_fd = fd;
 
 	return fd;

--- a/src/bluealsa-config.c
+++ b/src/bluealsa-config.c
@@ -34,6 +34,8 @@ struct ba_config config = {
 
 	.volume_init_level = 0,
 
+	.disable_realtek_usb_fix = false,
+
 	/* CVSD is a mandatory codec */
 	.hfp.codecs.cvsd = true,
 #if ENABLE_MSBC

--- a/src/bluealsa-config.h
+++ b/src/bluealsa-config.h
@@ -68,6 +68,9 @@ struct ba_config {
 	/* the initial volume level */
 	int volume_init_level;
 
+	/* disable alt-3 MTU for mSBC with Realtek USB adapters */
+	bool disable_realtek_usb_fix;
+
 	struct {
 
 		/* available HFP codecs */

--- a/src/bluez.c
+++ b/src/bluez.c
@@ -43,6 +43,7 @@
 #include "sco.h"
 #include "utils.h"
 #include "shared/a2dp-codecs.h"
+#include "shared/bluetooth.h"
 #include "shared/defs.h"
 #include "shared/log.h"
 
@@ -653,11 +654,11 @@ static void bluez_register_a2dp_all(struct ba_adapter *adapter) {
 		switch (c->dir) {
 		case A2DP_SOURCE:
 			if (config.profile.a2dp_source && c->enabled)
-				bluez_register_a2dp(adapter, c, BLUETOOTH_UUID_A2DP_SOURCE);
+				bluez_register_a2dp(adapter, c, BT_UUID_A2DP_SOURCE);
 			break;
 		case A2DP_SINK:
 			if (config.profile.a2dp_sink && c->enabled)
-				bluez_register_a2dp(adapter, c, BLUETOOTH_UUID_A2DP_SINK);
+				bluez_register_a2dp(adapter, c, BT_UUID_A2DP_SINK);
 			break;
 		}
 	}
@@ -1076,16 +1077,16 @@ fail:
  * this function will do nothing. */
 static void bluez_register_hfp_all(void) {
 	if (config.profile.hsp_hs)
-		bluez_register_hfp(BLUETOOTH_UUID_HSP_HS, BA_TRANSPORT_PROFILE_HSP_HS,
+		bluez_register_hfp(BT_UUID_HSP_HS, BA_TRANSPORT_PROFILE_HSP_HS,
 				0x0102 /* HSP 1.2 */, 0x1 /* remote audio volume control */);
 	if (config.profile.hsp_ag)
-		bluez_register_hfp(BLUETOOTH_UUID_HSP_AG, BA_TRANSPORT_PROFILE_HSP_AG,
+		bluez_register_hfp(BT_UUID_HSP_AG, BA_TRANSPORT_PROFILE_HSP_AG,
 				0x0102 /* HSP 1.2 */, 0x0);
 	if (config.profile.hfp_hf)
-		bluez_register_hfp(BLUETOOTH_UUID_HFP_HF, BA_TRANSPORT_PROFILE_HFP_HF,
+		bluez_register_hfp(BT_UUID_HFP_HF, BA_TRANSPORT_PROFILE_HFP_HF,
 				0x0107 /* HFP 1.7 */, config.hfp.features_sdp_hf);
 	if (config.profile.hfp_ag)
-		bluez_register_hfp(BLUETOOTH_UUID_HFP_AG, BA_TRANSPORT_PROFILE_HFP_AG,
+		bluez_register_hfp(BT_UUID_HFP_AG, BA_TRANSPORT_PROFILE_HFP_AG,
 				0x0107 /* HFP 1.7 */, config.hfp.features_sdp_ag);
 }
 
@@ -1099,17 +1100,17 @@ static void bluez_register(void) {
 		bool enabled;
 		bool global;
 	} uuids[] = {
-		{ BLUETOOTH_UUID_A2DP_SOURCE, BA_TRANSPORT_PROFILE_A2DP_SOURCE,
+		{ BT_UUID_A2DP_SOURCE, BA_TRANSPORT_PROFILE_A2DP_SOURCE,
 			config.profile.a2dp_source, false },
-		{ BLUETOOTH_UUID_A2DP_SINK, BA_TRANSPORT_PROFILE_A2DP_SINK,
+		{ BT_UUID_A2DP_SINK, BA_TRANSPORT_PROFILE_A2DP_SINK,
 			config.profile.a2dp_sink, false },
-		{ BLUETOOTH_UUID_HSP_HS, BA_TRANSPORT_PROFILE_HSP_HS,
+		{ BT_UUID_HSP_HS, BA_TRANSPORT_PROFILE_HSP_HS,
 			config.profile.hsp_hs, true },
-		{ BLUETOOTH_UUID_HSP_AG, BA_TRANSPORT_PROFILE_HSP_AG,
+		{ BT_UUID_HSP_AG, BA_TRANSPORT_PROFILE_HSP_AG,
 			config.profile.hsp_ag, true },
-		{ BLUETOOTH_UUID_HFP_HF, BA_TRANSPORT_PROFILE_HFP_HF,
+		{ BT_UUID_HFP_HF, BA_TRANSPORT_PROFILE_HFP_HF,
 			config.profile.hfp_hf, true },
-		{ BLUETOOTH_UUID_HFP_AG, BA_TRANSPORT_PROFILE_HFP_AG,
+		{ BT_UUID_HFP_AG, BA_TRANSPORT_PROFILE_HFP_AG,
 			config.profile.hfp_ag, true },
 	};
 
@@ -1238,7 +1239,7 @@ static void bluez_signal_interfaces_added(GDBusConnection *conn, const char *sen
 			while (g_variant_iter_next(properties, "{&sv}", &property, &value)) {
 				if (strcmp(property, "UUID") == 0) {
 					const char *uuid = g_variant_get_string(value, NULL);
-					if (strcasecmp(uuid, BLUETOOTH_UUID_A2DP_SINK) == 0)
+					if (strcasecmp(uuid, BT_UUID_A2DP_SINK) == 0)
 						sep.dir = A2DP_SINK;
 				}
 				else if (strcmp(property, "Codec") == 0)

--- a/src/bluez.h
+++ b/src/bluez.h
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - bluez.h
- * Copyright (c) 2016-2022 Arkadiusz Bokowy
+ * Copyright (c) 2016-2023 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -18,14 +18,6 @@
 
 #include "a2dp.h"
 #include "ba-device.h"
-
-/* List of Bluetooth audio profiles. */
-#define BLUETOOTH_UUID_A2DP_SOURCE "0000110A-0000-1000-8000-00805F9B34FB"
-#define BLUETOOTH_UUID_A2DP_SINK   "0000110B-0000-1000-8000-00805F9B34FB"
-#define BLUETOOTH_UUID_HSP_HS      "00001108-0000-1000-8000-00805F9B34FB"
-#define BLUETOOTH_UUID_HSP_AG      "00001112-0000-1000-8000-00805F9B34FB"
-#define BLUETOOTH_UUID_HFP_HF      "0000111E-0000-1000-8000-00805F9B34FB"
-#define BLUETOOTH_UUID_HFP_AG      "0000111F-0000-1000-8000-00805F9B34FB"
 
 #define BLUEZ_A2DP_VOLUME_MIN 0
 #define BLUEZ_A2DP_VOLUME_MAX 127

--- a/src/hci.h
+++ b/src/hci.h
@@ -22,22 +22,6 @@
 #include <bluetooth/hci.h> /* IWYU pragma: keep */
 #include <bluetooth/hci_lib.h>
 
-/**
- * List of all Bluetooth member companies:
- * https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers */
-
-#define BT_COMPID_INTEL              0x0002
-#define BT_COMPID_QUALCOMM_TECH_INTL 0x000A
-#define BT_COMPID_BROADCOM           0x000F
-#define BT_COMPID_APPLE              0x004C
-#define BT_COMPID_APT                0x004F
-#define BT_COMPID_SAMSUNG_ELEC       0x0075
-#define BT_COMPID_QUALCOMM_TECH      0x00D7
-#define BT_COMPID_SONY               0x012D
-#define BT_COMPID_CYPRESS            0x0131
-#define BT_COMPID_SAVITECH           0x053A
-#define BT_COMPID_FRAUNHOFER_IIS     0x08A9
-
 int hci_get_version(int dev_id, struct hci_version *ver);
 
 /**

--- a/src/hci.h
+++ b/src/hci.h
@@ -22,6 +22,8 @@
 #include <bluetooth/hci.h> /* IWYU pragma: keep */
 #include <bluetooth/hci_lib.h>
 
+#include "ba-adapter.h"
+
 int hci_get_version(int dev_id, struct hci_version *ver);
 
 /**
@@ -36,7 +38,8 @@ int hci_get_version(int dev_id, struct hci_version *ver);
 
 int hci_sco_open(int dev_id);
 int hci_sco_connect(int sco_fd, const bdaddr_t *ba, uint16_t voice);
-unsigned int hci_sco_get_mtu(int sco_fd, int hci_type);
+
+unsigned int hci_sco_get_mtu(int sco_fd, struct ba_adapter *a);
 
 #define BT_BCM_PARAM_ROUTING_PCM       0x0
 #define BT_BCM_PARAM_ROUTING_TRANSPORT 0x1

--- a/src/main.c
+++ b/src/main.c
@@ -156,6 +156,7 @@ int main(int argc, char **argv) {
 		{ "codec", required_argument, NULL, 'c' },
 		{ "initial-volume", required_argument, NULL, 17 },
 		{ "keep-alive", required_argument, NULL, 8 },
+		{ "disable-realtek-usb-fix", no_argument, NULL, 21 },
 		{ "a2dp-force-mono", no_argument, NULL, 6 },
 		{ "a2dp-force-audio-cd", no_argument, NULL, 7 },
 		{ "a2dp-volume", no_argument, NULL, 9 },
@@ -204,6 +205,7 @@ int main(int argc, char **argv) {
 					"  -c, --codec=NAME\t\tset enabled BT audio codecs\n"
 					"  --initial-volume=NUM\t\tinitial volume level [0-100]\n"
 					"  --keep-alive=SEC\t\tkeep Bluetooth transport alive\n"
+					"  --disable-realtek-usb-fix\tdisable fix for mSBC on Realtek USB\n"
 					"  --a2dp-force-mono\t\ttry to force monophonic sound\n"
 					"  --a2dp-force-audio-cd\t\ttry to force 44.1 kHz sampling\n"
 					"  --a2dp-volume\t\t\tnative volume control by default\n"
@@ -377,6 +379,10 @@ int main(int argc, char **argv) {
 
 		case 8 /* --keep-alive=SEC */ :
 			config.keep_alive_time = atof(optarg) * 1000;
+			break;
+
+		case 21 /* --disable-realtek-usb-fix */ :
+			config.disable_realtek_usb_fix = true;
 			break;
 
 		case 6 /* --a2dp-force-mono */ :

--- a/src/ofono.c
+++ b/src/ofono.c
@@ -32,7 +32,6 @@
 #include <unistd.h>
 
 #include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
 
 #include <gio/gio.h>
@@ -129,7 +128,7 @@ static int ofono_acquire_bt_sco(struct ba_transport *t) {
 #endif
 
 	t->bt_fd = fd;
-	t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, t->d->a->hci.type);
+	t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, t->d->a);
 	ba_transport_set_codec(t, codec);
 
 	debug("New oFono SCO link (codec: %#x): %d", codec, fd);
@@ -820,7 +819,7 @@ static void ofono_agent_new_connection(GDBusMethodInvocation *inv, void *userdat
 	debug("New oFono SCO link (codec: %#x): %d", codec, fd);
 
 	t->bt_fd = fd;
-	t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, t->d->a->hci.type);
+	t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, t->d->a);
 	ba_transport_set_codec(t, codec);
 
 	pthread_mutex_unlock(&t->bt_fd_mtx);

--- a/src/sco.c
+++ b/src/sco.c
@@ -37,6 +37,7 @@
 #include "hci.h"
 #include "hfp.h"
 #include "io.h"
+#include "shared/bluetooth.h"
 #include "shared/defs.h"
 #include "shared/ffb.h"
 #include "shared/log.h"

--- a/src/sco.c
+++ b/src/sco.c
@@ -144,7 +144,7 @@ static void *sco_dispatcher_thread(struct ba_adapter *a) {
 		pthread_mutex_lock(&t->bt_fd_mtx);
 
 		t->bt_fd = fd;
-		t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, a->hci.type);
+		t->mtu_read = t->mtu_write = hci_sco_get_mtu(fd, a);
 		fd = -1;
 
 		pthread_mutex_unlock(&t->bt_fd_mtx);

--- a/src/shared/a2dp-codecs.h
+++ b/src/shared/a2dp-codecs.h
@@ -34,7 +34,7 @@
 #include <endian.h>
 #include <stdint.h>
 
-#include "hci.h"
+#include "bluetooth.h"
 
 #define A2DP_CODEC_SBC      0x00
 #define A2DP_CODEC_MPEG12   0x01

--- a/src/shared/bluetooth.h
+++ b/src/shared/bluetooth.h
@@ -1,0 +1,41 @@
+/*
+ * BlueALSA - bluetooth.h
+ * Copyright (c) 2016-2023 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#pragma once
+#ifndef BLUEALSA_SHARED_BLUETOOTH_H_
+#define BLUEALSA_SHARED_BLUETOOTH_H_
+
+/**
+ * List of all Bluetooth member companies:
+ * https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers */
+
+#define BT_COMPID_INTEL              0x0002
+#define BT_COMPID_QUALCOMM_TECH_INTL 0x000A
+#define BT_COMPID_BROADCOM           0x000F
+#define BT_COMPID_APPLE              0x004C
+#define BT_COMPID_APT                0x004F
+#define BT_COMPID_SAMSUNG_ELEC       0x0075
+#define BT_COMPID_QUALCOMM_TECH      0x00D7
+#define BT_COMPID_SONY               0x012D
+#define BT_COMPID_CYPRESS            0x0131
+#define BT_COMPID_SAVITECH           0x053A
+#define BT_COMPID_FRAUNHOFER_IIS     0x08A9
+
+/**
+ * Bluetooth UUIDs associated with audio profiles. */
+
+#define BT_UUID_A2DP_SOURCE "0000110A-0000-1000-8000-00805F9B34FB"
+#define BT_UUID_A2DP_SINK   "0000110B-0000-1000-8000-00805F9B34FB"
+#define BT_UUID_HSP_HS      "00001108-0000-1000-8000-00805F9B34FB"
+#define BT_UUID_HSP_AG      "00001112-0000-1000-8000-00805F9B34FB"
+#define BT_UUID_HFP_HF      "0000111E-0000-1000-8000-00805F9B34FB"
+#define BT_UUID_HFP_AG      "0000111F-0000-1000-8000-00805F9B34FB"
+
+#endif

--- a/src/shared/bluetooth.h
+++ b/src/shared/bluetooth.h
@@ -21,6 +21,7 @@
 #define BT_COMPID_BROADCOM           0x000F
 #define BT_COMPID_APPLE              0x004C
 #define BT_COMPID_APT                0x004F
+#define BT_COMPID_REALTEK            0x005D
 #define BT_COMPID_SAMSUNG_ELEC       0x0075
 #define BT_COMPID_QUALCOMM_TECH      0x00D7
 #define BT_COMPID_SONY               0x012D

--- a/src/shared/log.h
+++ b/src/shared/log.h
@@ -20,7 +20,7 @@
 #include <stddef.h>
 #include <syslog.h>
 
-#include "shared/defs.h"
+#include "defs.h"
 
 void log_open(const char *ident, bool syslog);
 void log_message(int priority, const char *format, ...) __attribute__ ((format(printf, 2, 3)));

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -156,6 +156,7 @@ test_utils_SOURCES = \
 	../src/shared/log.c \
 	../src/shared/nv.c \
 	../src/shared/rt.c \
+	../src/bluealsa-config.c \
 	../src/hci.c \
 	../src/utils.c \
 	test-utils.c


### PR DESCRIPTION
Enables use of mSBC with Realtek USB adapters by applying a manufacturer-specific sco socket mtu value. This PR is a temporary measure until a more general mSBC over USB fix can be found (for example PR #550). See #637 for description of the problem being addressed.

Current BlueALSA sources result in silence being played, and bluealsa debug output shows `D: ../../src/hci.c:150: USB adjusted SCO MTU: 28: 24`. With this PR, audio is played correctly and bluealsa debug output shows `D: ../../src/hci.c:150: USB adjusted SCO MTU: 28: 72`

Fixes #637