### PR TITLE
Gitignore update

### DIFF
--- a/.github/spellcheck.yaml
+++ b/.github/spellcheck.yaml
@@ -22,7 +22,7 @@ matrix:
 
 - name: C
   sources:
-  - 'src/**/*.{c,h}|!config.h'
+  - 'src/**/*.{c,h}|!config.h|!src/*-iface.c'
   aspell: *aspell
   dictionary: *dict
   pipeline:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@
 Makefile.in
 config.h.in
 *~
+
+# Generated source files
+/src/bluealsa-iface.c
+/src/bluez-iface.c
+/src/ofono-iface.c


### PR DESCRIPTION
Since commit 2709a34, generated c source files are created in the src directory, and this can make some git actions such as switching branches awkward. These files also create problems when running spellcheck in a local work area. These
commits just make working with git a little bit easier.