### PR TITLE
Fix ofono socket authorization in HF role

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 unreleased
 ==========
 
+- fix for oFono HF role SCO socket authorization
+- fix for mSBC MTU adjustment for Realtek USB adapters
+
 bluez-alsa v4.1.0 (2023-05-23)
 ==============================
 


### PR DESCRIPTION
ofono support for the HF role was broken by commit d21ed50. This PR restores that support. Fixes #640
