### PR TITLE
SBC: Require sbc >= 1.5.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ Dependencies:
 - [alsa-lib](https://www.alsa-project.org/)
 - [bluez](http://www.bluez.org/) >= 5.0
 - [glib](https://wiki.gnome.org/Projects/GLib) with GIO support
-- [sbc](https://git.kernel.org/cgit/bluetooth/sbc.git)
+- [sbc](https://git.kernel.org/cgit/bluetooth/sbc.git) >= 1.5
 - [docutils](https://docutils.sourceforge.io) (when man pages build is enabled
   with `--enable-manpages`)
 - [fdk-aac](https://github.com/mstorsjo/fdk-aac) (when AAC support is enabled

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ PKG_CHECK_MODULES([BLUEZ], [bluez >= 5.0])
 PKG_CHECK_MODULES([DBUS1], [dbus-1 >= 1.6])
 PKG_CHECK_MODULES([GIO2], [gio-unix-2.0])
 PKG_CHECK_MODULES([GLIB2], [glib-2.0 >= 2.32])
-PKG_CHECK_MODULES([SBC], [sbc >= 1.2])
+PKG_CHECK_MODULES([SBC], [sbc >= 1.5])
 
 AC_PATH_PROGS([GDBUS_CODEGEN], [gdbus-codegen])
 AS_IF([test "x$GDBUS_CODEGEN" = "x"], [AC_MSG_ERROR([[gdbus-codegen not found]])])


### PR DESCRIPTION
  function sbc_reinit_a2dp was not exposed in the shared library until v1.5

See #639 

Use of sbc_reinit_a2dp was added in commit 44a5dd9a17eaf3b2a92ea2d1859b64f9837f2b4a

