### PR TITLE
Delay adjustment

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ unreleased
 
 - command line option to set real-time priority for IO threads
 - allow to select individual extended controls in ALSA plug-in
+- codec-specific delay adjustment with ALSA control and persistency
 
 bluez-alsa v4.1.1 (2023-06-24)
 ==============================

--- a/doc/bluealsa-api.txt
+++ b/doc/bluealsa-api.txt
@@ -64,6 +64,23 @@ Methods         fd, fd Open()
                                          dbus.Error.NotSupported
                                          dbus.Error.Failed
 
+                void SetDelayAdjustment(string codec, int16 adjustment)
+
+                        Set an arbitrary adjustment (+/-) to the reported Delay
+                        in 1/10 of millisecond for a specific codec. This
+                        adjustment is applied to the Delay property when that
+                        codec is selected, and can be used to compensate for
+                        devices that do not report accurate Delay values.
+
+                        Possible Errors: dbus.Error.InvalidArguments
+
+               array{string, int16} GetDelayAdjustments()
+
+                        Return the array of currently set delay adjustments.
+                        Each entry of the array gives the name of a codec and
+                        the adjustment that the PCM will apply to the Delay
+                        property when that codec is selected.
+
 Properties      object Device [readonly]
 
                         BlueZ device object path.
@@ -125,6 +142,12 @@ Properties      object Device [readonly]
                 uint16 Delay [readonly]
 
                         Approximate PCM delay in 1/10 of millisecond.
+
+                int16 DelayAdjustment [readonly]
+
+                        An adjustment (+/-) included within the reported Delay
+                        in 1/10 of millisecond to compensate for devices that
+                        do not report accurate delay values.
 
                 boolean SoftVolume [readwrite]
 

--- a/doc/bluealsa-cli.1.rst
+++ b/doc/bluealsa-cli.1.rst
@@ -6,7 +6,7 @@ bluealsa-cli
 a simple command line interface for the BlueALSA D-Bus API
 ----------------------------------------------------------
 
-:Date: January 2023
+:Date: July 2023
 :Manual section: 1
 :Manual group: General Commands Manual
 :Version: $VERSION$
@@ -61,7 +61,7 @@ status
     ::
 
         Service: org.bluealsa
-        Version: v3.1.0
+        Version: v4.1.1
         Adapters: hci0 hci1
         Profiles:
           A2DP-source : SBC AAC
@@ -147,6 +147,19 @@ soft-volume *PCM_PATH* [*STATE*]
     The *STATE* value can be one of **on**, **yes**, **true**, **y** or **1**
     for soft-volume on, or **off**, **no**, **false**, **n** or **0** for
     soft-volume off.
+
+delay-adjustment *PCM_PATH* [*ADJUSTMENT*]
+    Get or set the DelayAdjustment property of the given PCM for the current
+    codec.
+
+    If the *ADJUSTMENT* argument is given, set the DelayAdjustment property for
+    the current codec in the given PCM. This property may be used by clients to
+    adjust the reported audio delay and may be useful with PCM devices that do
+    not report an accurate Delay property.
+
+    The *ADJUSTMENT* value is in milliseconds and must be a decimal number with
+    optional sign prefix (e.g. **250**, **-500**, **+360.4**). The permitted
+    range is [-3276.8, 3276.7].
 
 monitor [-p[PROPS] | --properties[=PROPS]]
     Listen for D-Bus signals indicating adding/removing BlueALSA interfaces.

--- a/doc/bluealsa-plugins.7.rst
+++ b/doc/bluealsa-plugins.7.rst
@@ -98,9 +98,11 @@ PCM Parameters
     softvol value. The default value is **unchanged**.
 
   DELAY
-    An integer number which is added to the reported latency value in order to
-    manually adjust the audio synchronization. It is not normally required and
-    defaults to **0**.
+    An integer number which is added to the reported delay (latency) value in
+    order to manually adjust the audio synchronization. It is not normally
+    required and defaults to **0**. See the **EXT** parameter of the CTL plugin
+    in the `CTL Parameters`_ section below for a more flexible and convenient
+    method of manually adjusting the reported delay by using a mixer control.
 
   SRV
     The D-Bus service name of the BlueALSA daemon. Defaults to
@@ -420,15 +422,15 @@ CTL Parameters
 
   EXT
     Causes the plugin to include extra controls. These are the controls for
-    Bluetooth codec selection, volume mode selection and/or battery level
-    indicator.
+    Bluetooth codec selection, volume mode selection, delay adjustment (sync)
+    and/or battery level indicator.
     If the value is **yes** then all of these additional controls are included;
     if the value is **no** then none of them are included. The default is
     **no**.
 
     This parameter can also select individual controls by using a colon (':')
     separated list of control names. The control names are **codec**, **mode**,
-    and **battery**. For example:
+    **sync** and **battery**. For example:
 
     ::
 
@@ -442,6 +444,19 @@ CTL Parameters
     playback control has index 0 and capture control has index 1.
     See the `Volume control` section in the ``bluealsa(8)`` for more
     information on the software volume setting.
+
+    The delay adjustment controls are called "Sync". They can be used to apply
+    a fixed adjustment to the delay reported by the associated PCM to the
+    application, and may be useful with applications that need to synchronize
+    the bluetooth audio stream with some some other stream, such as a video.
+    The values are in milliseconds from ``-3275 ms`` to ``+3275 ms`` in steps
+    of ``25 ms``. The playback control has index 0 and the capture control has
+    index 1. Each codec supported by a PCM has its own delay adjustment value.
+    Note that this control changes only the delay value reported to the
+    application by ALSA, it does not affect the actual delay (latency) of the
+    PCM stream. Values set by this control type are saved in the BlueALSA
+    persistent state files, and so are remembered and automatically applied
+    each time the PCM is used.
 
     The read-only battery level indicator will be shown only if the device
     supports battery level reporting.

--- a/misc/bash-completion/bluealsa
+++ b/misc/bash-completion/bluealsa
@@ -286,7 +286,7 @@ _bluealsa_cli() {
 
 	# the command names supported by this version of bluealsa-cli
 	local simple_commands="list-pcms list-services monitor status"
-	local path_commands="codec info mute open soft-volume volume"
+	local path_commands="codec delay-adjustment info mute open soft-volume volume"
 
 	# options that may appear before or after the command
 	local global_shortopts="-h"

--- a/src/ba-transport.h
+++ b/src/ba-transport.h
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <time.h>
 
+#include <glib.h>
+
 #include "a2dp.h"
 #include "ba-device.h"
 #include "bluez.h"
@@ -81,6 +83,12 @@ struct ba_transport_pcm {
 	/* Overall PCM delay in 1/10 of millisecond, caused by
 	 * audio encoding or decoding and data transfer. */
 	unsigned int delay;
+
+	/* guard delay adjustments access */
+	pthread_mutex_t delay_adjustments_mtx;
+	/* PCM delay adjustments in 1/10 of millisecond, set by client API to allow
+	 * user correction of delay reporting inaccuracy. */
+	GHashTable *delay_adjustments;
 
 	/* indicates whether FIFO buffer was synchronized */
 	bool synced;
@@ -422,6 +430,13 @@ bool ba_transport_pcm_is_active(
 
 int ba_transport_pcm_get_delay(
 		const struct ba_transport_pcm *pcm);
+
+int16_t ba_transport_pcm_delay_adjustment_get(
+		const struct ba_transport_pcm *pcm);
+void ba_transport_pcm_delay_adjustment_set(
+		struct ba_transport_pcm *pcm,
+		uint16_t codec_id,
+		int16_t adjustment);
 
 int ba_transport_pcm_volume_update(
 		struct ba_transport_pcm *pcm);

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -259,6 +259,10 @@ static GVariant *ba_variant_new_pcm_delay(const struct ba_transport_pcm *pcm) {
 	return g_variant_new_uint16(ba_transport_pcm_get_delay(pcm));
 }
 
+static GVariant *ba_variant_new_pcm_delay_adjustment(const struct ba_transport_pcm *pcm) {
+	return g_variant_new_int16(ba_transport_pcm_delay_adjustment_get(pcm));
+}
+
 static GVariant *ba_variant_new_pcm_soft_volume(const struct ba_transport_pcm *pcm) {
 	return g_variant_new_boolean(pcm->soft_volume);
 }
@@ -295,6 +299,7 @@ static void ba_variant_populate_pcm(GVariantBuilder *props, const struct ba_tran
 	if ((value = ba_variant_new_pcm_codec_config(pcm)) != NULL)
 		g_variant_builder_add(props, "{sv}", "CodecConfiguration", value);
 	g_variant_builder_add(props, "{sv}", "Delay", ba_variant_new_pcm_delay(pcm));
+	g_variant_builder_add(props, "{sv}", "DelayAdjustment", ba_variant_new_pcm_delay_adjustment(pcm));
 	g_variant_builder_add(props, "{sv}", "SoftVolume", ba_variant_new_pcm_soft_volume(pcm));
 	g_variant_builder_add(props, "{sv}", "Volume", ba_variant_new_pcm_volume(pcm));
 
@@ -764,6 +769,74 @@ final:
 		g_variant_unref(value);
 }
 
+static void bluealsa_pcm_set_delay_adjustment(GDBusMethodInvocation *inv, void *userdata) {
+
+	struct ba_transport_pcm *pcm = (struct ba_transport_pcm *)userdata;
+	GVariant *params = g_dbus_method_invocation_get_parameters(inv);
+	const struct ba_transport *t = pcm->t;
+
+	const char *codec;
+	int16_t adjustment;
+
+	g_variant_get(params, "(&sn)", &codec, &adjustment);
+
+	uint16_t codec_id = 0;
+	bool is_valid = false;
+	if (t->profile & BA_TRANSPORT_PROFILE_MASK_A2DP) {
+		codec_id = a2dp_codecs_codec_id_from_string(codec);
+		is_valid = codec_id != 0xFFFF;
+	}
+	if (t->profile & BA_TRANSPORT_PROFILE_MASK_SCO) {
+		codec_id = hfp_codec_id_from_string(codec);
+		is_valid = codec_id != HFP_CODEC_UNDEFINED;
+	}
+
+	if (!is_valid) {
+		error("Invalid codec name: %s", codec);
+		g_dbus_method_invocation_return_error(inv, G_DBUS_ERROR,
+				G_DBUS_ERROR_INVALID_ARGS, "Invalid codec name: %s", codec);
+		return;
+	}
+
+	ba_transport_pcm_delay_adjustment_set(pcm, codec_id, adjustment);
+	bluealsa_dbus_pcm_update(pcm, BA_DBUS_PCM_UPDATE_DELAY_ADJUSTMENT);
+	g_dbus_method_invocation_return_value(inv, NULL);
+
+}
+
+static void bluealsa_pcm_get_delay_adjustments(GDBusMethodInvocation *inv, void *userdata) {
+
+	struct ba_transport_pcm *pcm = (struct ba_transport_pcm *)userdata;
+	const struct ba_transport *t = pcm->t;
+
+	GVariantBuilder adjustments;
+	g_variant_builder_init(&adjustments, G_VARIANT_TYPE("a{sn}"));
+
+	pthread_mutex_lock(&pcm->delay_adjustments_mtx);
+
+	GHashTableIter iter;
+	g_hash_table_iter_init(&iter, pcm->delay_adjustments);
+
+	void *key, *value;
+	while (g_hash_table_iter_next(&iter, &key, &value)) {
+		const char *codec = NULL;
+		if (t->profile & BA_TRANSPORT_PROFILE_MASK_A2DP)
+			codec = a2dp_codecs_codec_id_to_string(GPOINTER_TO_INT(key));
+		if (t->profile & BA_TRANSPORT_PROFILE_MASK_SCO)
+			codec = hfp_codec_id_to_string(GPOINTER_TO_INT(key));
+		if (codec != NULL) {
+			int16_t adjustment = GPOINTER_TO_INT(value);
+			g_variant_builder_add(&adjustments, "{sn}", codec, adjustment);
+		}
+	}
+
+	pthread_mutex_unlock(&pcm->delay_adjustments_mtx);
+
+	g_dbus_method_invocation_return_value(inv, g_variant_new("(a{sn})", &adjustments));
+	g_variant_builder_clear(&adjustments);
+
+}
+
 static void bluealsa_rfcomm_open(GDBusMethodInvocation *inv, void *userdata) {
 
 	struct ba_rfcomm *r = (struct ba_rfcomm *)userdata;
@@ -836,6 +909,8 @@ static GVariant *bluealsa_pcm_get_property(const char *property,
 	}
 	if (strcmp(property, "Delay") == 0)
 		return ba_variant_new_pcm_delay(pcm);
+	if (strcmp(property, "DelayAdjustment") == 0)
+		return ba_variant_new_pcm_delay_adjustment(pcm);
 	if (strcmp(property, "SoftVolume") == 0)
 		return ba_variant_new_pcm_soft_volume(pcm);
 	if (strcmp(property, "Volume") == 0)
@@ -905,6 +980,10 @@ int bluealsa_dbus_pcm_register(struct ba_transport_pcm *pcm) {
 			.handler = bluealsa_pcm_get_codecs },
 		{ .method = "SelectCodec",
 			.handler = bluealsa_pcm_select_codec },
+		{ .method = "SetDelayAdjustment",
+			.handler = bluealsa_pcm_set_delay_adjustment },
+		{ .method = "GetDelayAdjustments",
+			.handler = bluealsa_pcm_get_delay_adjustments },
 		{ 0 },
 	};
 
@@ -961,8 +1040,10 @@ void bluealsa_dbus_pcm_update(struct ba_transport_pcm *pcm, unsigned int mask) {
 		g_variant_builder_add(&props, "{sv}", "Codec", ba_variant_new_pcm_codec(pcm));
 	if (mask & BA_DBUS_PCM_UPDATE_CODEC_CONFIG)
 		g_variant_builder_add(&props, "{sv}", "CodecConfiguration", ba_variant_new_pcm_codec_config(pcm));
-	if (mask & BA_DBUS_PCM_UPDATE_DELAY)
+	if (mask & (BA_DBUS_PCM_UPDATE_DELAY | BA_DBUS_PCM_UPDATE_DELAY_ADJUSTMENT))
 		g_variant_builder_add(&props, "{sv}", "Delay", ba_variant_new_pcm_delay(pcm));
+	if (mask & BA_DBUS_PCM_UPDATE_DELAY_ADJUSTMENT)
+		g_variant_builder_add(&props, "{sv}", "DelayAdjustment", ba_variant_new_pcm_delay_adjustment(pcm));
 	if (mask & BA_DBUS_PCM_UPDATE_SOFT_VOLUME)
 		g_variant_builder_add(&props, "{sv}", "SoftVolume", ba_variant_new_pcm_soft_volume(pcm));
 	if (mask & BA_DBUS_PCM_UPDATE_VOLUME)

--- a/src/bluealsa-dbus.h
+++ b/src/bluealsa-dbus.h
@@ -22,15 +22,16 @@
 #include "ba-device.h"
 #include "ba-transport.h"
 
-#define BA_DBUS_PCM_UPDATE_FORMAT       (1 << 0)
-#define BA_DBUS_PCM_UPDATE_CHANNELS     (1 << 1)
-#define BA_DBUS_PCM_UPDATE_SAMPLING     (1 << 2)
-#define BA_DBUS_PCM_UPDATE_CODEC        (1 << 3)
-#define BA_DBUS_PCM_UPDATE_CODEC_CONFIG (1 << 4)
-#define BA_DBUS_PCM_UPDATE_DELAY        (1 << 5)
-#define BA_DBUS_PCM_UPDATE_SOFT_VOLUME  (1 << 6)
-#define BA_DBUS_PCM_UPDATE_VOLUME       (1 << 7)
-#define BA_DBUS_PCM_UPDATE_RUNNING      (1 << 8)
+#define BA_DBUS_PCM_UPDATE_FORMAT           (1 << 0)
+#define BA_DBUS_PCM_UPDATE_CHANNELS         (1 << 1)
+#define BA_DBUS_PCM_UPDATE_SAMPLING         (1 << 2)
+#define BA_DBUS_PCM_UPDATE_CODEC            (1 << 3)
+#define BA_DBUS_PCM_UPDATE_CODEC_CONFIG     (1 << 4)
+#define BA_DBUS_PCM_UPDATE_DELAY            (1 << 5)
+#define BA_DBUS_PCM_UPDATE_DELAY_ADJUSTMENT (1 << 6)
+#define BA_DBUS_PCM_UPDATE_SOFT_VOLUME      (1 << 7)
+#define BA_DBUS_PCM_UPDATE_VOLUME           (1 << 8)
+#define BA_DBUS_PCM_UPDATE_RUNNING          (1 << 9)
 
 #define BA_DBUS_RFCOMM_UPDATE_FEATURES (1 << 0)
 #define BA_DBUS_RFCOMM_UPDATE_BATTERY  (1 << 1)

--- a/src/bluealsa-iface.xml
+++ b/src/bluealsa-iface.xml
@@ -26,6 +26,13 @@
 			<arg direction="in" type="s" name="codec"/>
 			<arg direction="in" type="a{sv}" name="props"/>
 		</method>
+		<method name="SetDelayAdjustment">
+			<arg direction="in" type="s" name="codec"/>
+			<arg direction="in" type="n" name="adjustment"/>
+		</method>
+		<method name="GetDelayAdjustments">
+			<arg direction="out" type="a{sn}" name="adjustments"/>
+		</method>
 		<property name="Device" type="o" access="read"/>
 		<property name="Sequence" type="u" access="read"/>
 		<property name="Transport" type="s" access="read"/>
@@ -37,6 +44,7 @@
 		<property name="Codec" type="s" access="read"/>
 		<property name="CodecConfiguration" type="ay" access="read"/>
 		<property name="Delay" type="q" access="read"/>
+		<property name="DelayAdjustment" type="n" access="read"/>
 		<property name="SoftVolume" type="b" access="readwrite"/>
 		<property name="Volume" type="q" access="readwrite"/>
 	</interface>

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -165,6 +165,8 @@ struct ba_pcm {
 	struct ba_pcm_codec codec;
 	/* approximate PCM delay */
 	dbus_uint16_t delay;
+	/* manual delay adjustment */
+	dbus_int16_t delay_adjustment;
 	/* software volume */
 	dbus_bool_t soft_volume;
 
@@ -276,6 +278,13 @@ dbus_bool_t bluealsa_dbus_pcm_select_codec(
 		const char *codec,
 		const void *configuration,
 		size_t configuration_len,
+		DBusError *error);
+
+dbus_bool_t bluealsa_dbus_pcm_set_delay_adjustment(
+		struct ba_dbus_ctx *ctx,
+		const char *pcm_path,
+		const char *codec,
+		int16_t adjustment,
 		DBusError *error);
 
 dbus_bool_t bluealsa_dbus_open_rfcomm(

--- a/src/shared/defs.h
+++ b/src/shared/defs.h
@@ -19,6 +19,10 @@
 #define ARRAYSIZE(a) (sizeof(a) / sizeof(*(a)))
 
 /**
+ * Divide integers with rounding. */
+#define DIV_ROUND(n, d) (((n) + (d) / 2) / (d))
+
+/**
  * Divide integers with rounding up. */
 #define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -84,6 +84,7 @@ test_audio_SOURCES = \
 	test-audio.c
 
 test_ba_SOURCES = \
+	../src/shared/a2dp-codecs.c \
 	../src/shared/ffb.c \
 	../src/shared/log.c \
 	../src/shared/rt.c \
@@ -94,6 +95,7 @@ test_ba_SOURCES = \
 	../src/codec-sbc.c \
 	../src/dbus.c \
 	../src/hci.c \
+	../src/hfp.c \
 	../src/io.c \
 	../src/sco.c \
 	../src/storage.c \
@@ -129,6 +131,7 @@ test_msbc_SOURCES = \
 endif
 
 test_rfcomm_SOURCES = \
+	../src/shared/a2dp-codecs.c \
 	../src/shared/log.c \
 	../src/shared/rt.c \
 	../src/at.c \

--- a/test/test-alsa-ctl.c
+++ b/test/test-alsa-ctl.c
@@ -142,14 +142,14 @@ CK_START_TEST(test_controls_extended) {
 	snd_ctl_elem_list_alloca(&elems);
 
 	ck_assert_int_eq(snd_ctl_elem_list(ctl, elems), 0);
-	ck_assert_int_eq(snd_ctl_elem_list_get_count(elems), 16);
-	ck_assert_int_eq(snd_ctl_elem_list_alloc_space(elems, 16), 0);
+	ck_assert_int_eq(snd_ctl_elem_list_get_count(elems), 20);
+	ck_assert_int_eq(snd_ctl_elem_list_alloc_space(elems, 20), 0);
 	ck_assert_int_eq(snd_ctl_elem_list(ctl, elems), 0);
 
 	/* codec control element shall be after playback/capture elements */
 	ck_assert_str_eq(snd_ctl_elem_list_get_name(elems, 3), "12:34:56:78:9A:BC A2DP Codec Enum");
-	ck_assert_str_eq(snd_ctl_elem_list_get_name(elems, 10), "12:34:56:78:9A:BC SCO Codec Enum");
-	ck_assert_str_eq(snd_ctl_elem_list_get_name(elems, 15), "23:45:67:89:AB:CD A2DP Codec Enum");
+	ck_assert_str_eq(snd_ctl_elem_list_get_name(elems, 11), "12:34:56:78:9A:BC SCO Codec Enum");
+	ck_assert_str_eq(snd_ctl_elem_list_get_name(elems, 18), "23:45:67:89:AB:CD A2DP Codec Enum");
 
 	bool has_msbc = false;
 #if ENABLE_MSBC
@@ -160,7 +160,7 @@ CK_START_TEST(test_controls_extended) {
 	snd_ctl_elem_info_alloca(&info);
 
 	/* 12:34:56:78:9A:BC SCO Codec Enum */
-	snd_ctl_elem_info_set_numid(info, snd_ctl_elem_list_get_numid(elems, 10));
+	snd_ctl_elem_info_set_numid(info, snd_ctl_elem_list_get_numid(elems, 11));
 	ck_assert_int_eq(snd_ctl_elem_info(ctl, info), 0);
 	ck_assert_int_eq(snd_ctl_elem_info_get_items(info), has_msbc ? 2 : 1);
 	snd_ctl_elem_info_set_item(info, 0);
@@ -186,7 +186,7 @@ CK_START_TEST(test_controls_extended) {
 	ck_assert_int_eq(snd_ctl_elem_write(ctl, elem), 0);
 
 	/* 12:34:56:78:9A:BC SCO Codec Enum */
-	snd_ctl_elem_value_set_numid(elem, snd_ctl_elem_list_get_numid(elems, 10));
+	snd_ctl_elem_value_set_numid(elem, snd_ctl_elem_list_get_numid(elems, 11));
 	/* get currently selected SCO codec */
 	ck_assert_int_eq(snd_ctl_elem_read(ctl, elem), 0);
 	ck_assert_int_eq(snd_ctl_elem_value_get_enumerated(elem, 0), has_msbc ? 1 : 0);

--- a/test/test-utils-cli.c
+++ b/test/test-utils-cli.c
@@ -241,6 +241,40 @@ CK_START_TEST(test_codec) {
 
 } CK_END_TEST
 
+CK_START_TEST(test_delay_adjustment) {
+
+	struct spawn_process sp_ba_mock;
+	ck_assert_int_ne(spawn_bluealsa_mock(&sp_ba_mock, NULL, true,
+				"--profile=a2dp-source",
+				NULL), -1);
+
+	char output[4096];
+
+	/* check printing help text */
+	ck_assert_int_eq(run_bluealsa_cli(output, sizeof(output),
+				"delay-adjustment", "--help", NULL), 0);
+	ck_assert_ptr_ne(strstr(output, "-h, --help"), NULL);
+
+	/* check default delay adjustment */
+	ck_assert_int_eq(run_bluealsa_cli(output, sizeof(output),
+				"delay-adjustment", "/org/bluealsa/hci0/dev_12_34_56_78_9A_BC/a2dpsrc/sink",
+				NULL), 0);
+	ck_assert_ptr_ne(strstr(output, "DelayAdjustment: 0.0 ms"), NULL);
+
+	/* check setting delay adjustment */
+	ck_assert_int_eq(run_bluealsa_cli(output, sizeof(output),
+				"delay-adjustment", "/org/bluealsa/hci0/dev_12_34_56_78_9A_BC/a2dpsrc/sink", "-7.5",
+				NULL), 0);
+	ck_assert_int_eq(run_bluealsa_cli(output, sizeof(output),
+				"delay-adjustment", "/org/bluealsa/hci0/dev_12_34_56_78_9A_BC/a2dpsrc/sink",
+				NULL), 0);
+	ck_assert_ptr_ne(strstr(output, "DelayAdjustment: -7.5 ms"), NULL);
+
+	spawn_terminate(&sp_ba_mock, 0);
+	spawn_close(&sp_ba_mock, NULL);
+
+} CK_END_TEST
+
 CK_START_TEST(test_volume) {
 
 	struct spawn_process sp_ba_mock;
@@ -434,6 +468,7 @@ int main(int argc, char *argv[], char *envp[]) {
 	tcase_add_test(tc, test_list_pcms);
 	tcase_add_test(tc, test_info);
 	tcase_add_test(tc, test_codec);
+	tcase_add_test(tc, test_delay_adjustment);
 	tcase_add_test(tc, test_volume);
 	tcase_add_test(tc, test_monitor);
 	tcase_add_test(tc, test_open);

--- a/utils/cli/Makefile.am
+++ b/utils/cli/Makefile.am
@@ -11,6 +11,7 @@ bluealsa_cli_SOURCES = \
 	../../src/shared/hex.c \
 	../../src/shared/log.c \
 	cmd-codec.c \
+	cmd-delay-adjustment.c \
 	cmd-info.c \
 	cmd-list-pcms.c \
 	cmd-list-services.c \

--- a/utils/cli/cli.c
+++ b/utils/cli/cli.c
@@ -283,6 +283,7 @@ void cli_print_pcm_properties(const struct ba_pcm *pcm, DBusError *err) {
 	cli_print_pcm_available_codecs(pcm, err);
 	cli_print_pcm_selected_codec(pcm);
 	printf("Delay: %#.1f ms\n", (double)pcm->delay / 10);
+	printf("DelayAdjustment: %#.1f ms\n", (double)pcm->delay_adjustment / 10);
 	cli_print_pcm_soft_volume(pcm);
 	cli_print_pcm_volume(pcm);
 	cli_print_pcm_mute(pcm);
@@ -306,6 +307,7 @@ extern const struct cli_command cmd_list_pcms;
 extern const struct cli_command cmd_status;
 extern const struct cli_command cmd_info;
 extern const struct cli_command cmd_codec;
+extern const struct cli_command cmd_delay_adjustment;
 extern const struct cli_command cmd_monitor;
 extern const struct cli_command cmd_mute;
 extern const struct cli_command cmd_open;
@@ -318,6 +320,7 @@ static const struct cli_command *commands[] = {
 	&cmd_status,
 	&cmd_info,
 	&cmd_codec,
+	&cmd_delay_adjustment,
 	&cmd_volume,
 	&cmd_mute,
 	&cmd_softvol,

--- a/utils/cli/cmd-delay-adjustment.c
+++ b/utils/cli/cmd-delay-adjustment.c
@@ -1,0 +1,101 @@
+/*
+ * BlueALSA - cmd-delay-adjustment.c
+ * Copyright (c) 2016-2023 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <dbus/dbus.h>
+
+#include "cli.h"
+#include "shared/dbus-client.h"
+
+static void usage(const char *command) {
+	printf("Get or set the delay adjustment of the given PCM.\n\n");
+	cli_print_usage("%s [OPTION]... PCM-PATH [ADJUSTMENT]", command);
+	printf("\nOptions:\n"
+			"  -h, --help\t\tShow this message and exit\n"
+			"\nPositional arguments:\n"
+			"  PCM-PATH\tBlueALSA PCM D-Bus object path\n"
+			"  ADJUSTMENT\tAdjustment value (+/-), in milliseconds\n"
+	);
+}
+
+static int cmd_delay_adjustment_func(int argc, char *argv[]) {
+
+	int opt;
+	const char *opts = "+h";
+	const struct option longopts[] = {
+		{ "help", no_argument, NULL, 'h' },
+		{ 0 },
+	};
+
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, opts, longopts, NULL)) != -1)
+		if (opt == 'h') { /* --help */
+			usage(argv[0]);
+			return EXIT_SUCCESS;
+		}
+
+	if (argc - optind < 1) {
+		cmd_print_error("Missing BlueALSA PCM path argument");
+		return EXIT_FAILURE;
+	}
+	if (argc - optind > 2) {
+		cmd_print_error("Invalid number of arguments");
+		return EXIT_FAILURE;
+	}
+
+	DBusError err = DBUS_ERROR_INIT;
+	const char *path = argv[optind];
+
+	struct ba_pcm pcm;
+	if (!cli_get_ba_pcm(path, &pcm, &err)) {
+		cmd_print_error("Couldn't get BlueALSA PCM: %s", err.message);
+		return EXIT_FAILURE;
+	}
+
+	if (argc == 2) {
+		printf("DelayAdjustment: %#.1f ms\n", (double)pcm.delay_adjustment/ 10);
+		return EXIT_SUCCESS;
+	}
+
+	const char *value = argv[optind + 1];
+	errno = 0;
+	char *endptr = NULL;
+	double dbl = strtod(value, &endptr);
+	if (endptr == value || errno == ERANGE) {
+		cmd_print_error("Invalid argument: %s", value);
+		return EXIT_FAILURE;
+	}
+
+	int adjustment = lround(dbl * 10.0);
+	if (adjustment < INT16_MIN || adjustment > INT16_MAX) {
+		cmd_print_error("Invalid argument: %s", value);
+		return EXIT_FAILURE;
+	}
+
+	if (!bluealsa_dbus_pcm_set_delay_adjustment(&config.dbus, pcm.pcm_path,
+				pcm.codec.name, adjustment, &err)) {
+		cmd_print_error("DelayAdjustment update failed: %s", err.message);
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}
+
+const struct cli_command cmd_delay_adjustment = {
+	"delay-adjustment",
+	"Get or set PCM delay adjustment",
+	cmd_delay_adjustment_func,
+};


### PR DESCRIPTION
See discussion #650 for rationale. Extends the D-Bus API org.bluealsa.PCM1 to allow setting a persistent adjustment that is applied to the Delay property of the PCM. Each codec supported by the PCM has its own delay adjustment.

The choice of control name for the CTL plugin is not yet agreed, and in this initial draft the name "Sync" is used.   
