### PR TITLE
src/Makefile.am: Install D-Bus policy in /usr/share, not /etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,7 +342,7 @@ AC_SUBST([ALSA_CONF_DIR], [$alsaconfdir])
 AC_ARG_WITH([dbusconfdir],
 	AS_HELP_STRING([--with-dbusconfdir=DIR], [path to D-Bus system bus configuration files]),
 	[dbusconfdir="${withval}"],
-	[dbusconfdir=$($PKG_CONFIG --variable=sysconfdir dbus-1)/dbus-1/system.d])
+	[dbusconfdir=$($PKG_CONFIG --variable=datadir dbus-1)/dbus-1/system.d])
 AC_SUBST([DBUS_CONF_DIR], [$dbusconfdir])
 
 AC_ARG_WITH([systemdsystemunitdir],


### PR DESCRIPTION
From https://bugs.debian.org/1006631:

> dbus supports policy files in both `/usr/share/dbus-1/system.d` and
> `/etc/dbus-1/systemd`. [The] recently released dbus 1.14.0, officially
> deprecates installing packages' default policies into `/etc/dbus-1/systemd`,
> instead reserving it for the sysadmin. This is the same idea as the
> difference between `/usr/lib/udev/rules.d` and `/etc/udev/rules.d`.
