### PR TITLE
Fix adjust volume invalid in using soft volume for sco

### DIFF
--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -842,12 +842,12 @@ struct ba_transport *ba_transport_new_a2dp(
 	transport_pcm_init(&t->a2dp.pcm,
 			is_sink ? &t->thread_dec : &t->thread_enc,
 			is_sink ? BA_TRANSPORT_PCM_MODE_SOURCE : BA_TRANSPORT_PCM_MODE_SINK);
-	t->a2dp.pcm.soft_volume = !config.a2dp.volume;
+	t->a2dp.pcm.soft_volume = !config.volume;
 
 	transport_pcm_init(&t->a2dp.pcm_bc,
 			is_sink ? &t->thread_enc : &t->thread_dec,
 			is_sink ?  BA_TRANSPORT_PCM_MODE_SINK : BA_TRANSPORT_PCM_MODE_SOURCE);
-	t->a2dp.pcm_bc.soft_volume = !config.a2dp.volume;
+	t->a2dp.pcm_bc.soft_volume = !config.volume;
 
 	t->acquire = transport_acquire_bt_a2dp;
 	t->release = transport_release_bt_a2dp;
@@ -957,10 +957,12 @@ struct ba_transport *ba_transport_new_sco(
 	transport_pcm_init(&t->sco.spk_pcm,
 			is_ag ? &t->thread_enc : &t->thread_dec,
 			is_ag ? BA_TRANSPORT_PCM_MODE_SINK : BA_TRANSPORT_PCM_MODE_SOURCE);
+	t->sco.spk_pcm.soft_volume = !config.volume;
 
 	transport_pcm_init(&t->sco.mic_pcm,
 			is_ag ? &t->thread_dec : &t->thread_enc,
 			is_ag ? BA_TRANSPORT_PCM_MODE_SOURCE : BA_TRANSPORT_PCM_MODE_SINK);
+	t->sco.mic_pcm.soft_volume = !config.volume;
 
 	t->acquire = transport_acquire_bt_sco;
 	t->release = transport_release_bt_sco;

--- a/src/bluealsa-config.c
+++ b/src/bluealsa-config.c
@@ -85,7 +85,8 @@ struct ba_config config = {
 	.battery.available = false,
 	.battery.level = 100,
 
-	.a2dp.volume = false,
+	.volume = false,
+
 	.a2dp.force_mono = false,
 	.a2dp.force_44100 = false,
 

--- a/src/bluealsa-config.h
+++ b/src/bluealsa-config.h
@@ -112,10 +112,6 @@ struct ba_config {
 		/* NULL-terminated list of available A2DP codecs */
 		const struct bluez_a2dp_codec **codecs;
 
-		/* Control audio volume natively by the connected device. The disadvantage
-		 * of this control type is a monophonic volume change. */
-		bool volume;
-
 		/* Support for monophonic sound in the A2DP profile is mandatory for
 		 * sink and semi-mandatory for source. So, if one wants only the bare
 		 * minimum, it would be possible - e.g. due to bandwidth limitations. */
@@ -126,6 +122,10 @@ struct ba_config {
 		bool force_44100;
 
 	} a2dp;
+
+	/* Control audio volume natively by the connected device. The disadvantage
+	 * of this control type is a monophonic volume change. */
+	bool volume;
 
 	/* BlueALSA supports 5 SBC qualities: low, medium, high, XQ and XQ+. The XQ
 	 * mode uses 44.1 kHz sampling rate, dual channel mode with bitpool 38, 16

--- a/src/main.c
+++ b/src/main.c
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
 					"  --disable-realtek-usb-fix\tdisable fix for mSBC on Realtek USB\n"
 					"  --a2dp-force-mono\t\ttry to force monophonic sound\n"
 					"  --a2dp-force-audio-cd\t\ttry to force 44.1 kHz sampling\n"
-					"  --a2dp-volume\t\t\tnative volume control by default\n"
+					"  --native-volume\t\t\tnative volume control by default\n"
 					"  --sbc-quality=MODE\t\tset SBC encoder quality mode\n"
 #if ENABLE_AAC
 					"  --aac-afterburner\t\tenable FDK AAC afterburner\n"
@@ -404,8 +404,8 @@ int main(int argc, char **argv) {
 		case 7 /* --a2dp-force-audio-cd */ :
 			config.a2dp.force_44100 = true;
 			break;
-		case 9 /* --a2dp-volume */ :
-			config.a2dp.volume = true;
+		case 9 /* --native-volume */ :
+			config.volume = true;
 			break;
 
 		case 14 /* --sbc-quality=MODE */ : {


### PR DESCRIPTION
When using software volume, the sco volume cannot be adjusted, while it is normal in a2dp mode, so rename a2dp.volume to volume, and both a2dp/sco profiles can use it.