### PR TITLE
Fix adjust volume invalid in using soft volume for hfp

### DIFF
--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -957,10 +957,12 @@ struct ba_transport *ba_transport_new_sco(
 	transport_pcm_init(&t->sco.spk_pcm,
 			is_ag ? &t->thread_enc : &t->thread_dec,
 			is_ag ? BA_TRANSPORT_PCM_MODE_SINK : BA_TRANSPORT_PCM_MODE_SOURCE);
+	t->sco.spk_pcm.soft_volume = !config.hfp.volume;
 
 	transport_pcm_init(&t->sco.mic_pcm,
 			is_ag ? &t->thread_dec : &t->thread_enc,
 			is_ag ? BA_TRANSPORT_PCM_MODE_SOURCE : BA_TRANSPORT_PCM_MODE_SINK);
+	t->sco.mic_pcm.soft_volume = !config.hfp.volume;
 
 	t->acquire = transport_acquire_bt_sco;
 	t->release = transport_release_bt_sco;

--- a/src/bluealsa-config.h
+++ b/src/bluealsa-config.h
@@ -99,6 +99,8 @@ struct ba_config {
 		const char *xapl_product_name;
 		unsigned int xapl_features;
 
+		/* Control audio volume natively by the connected device. */
+		bool volume;
 	} hfp;
 
 	struct {
@@ -124,7 +126,6 @@ struct ba_config {
 		 * for sink endpoint and semi-mandatory for source. It is then possible
 		 * to force lower sampling in order to save Bluetooth bandwidth. */
 		bool force_44100;
-
 	} a2dp;
 
 	/* BlueALSA supports 5 SBC qualities: low, medium, high, XQ and XQ+. The XQ

--- a/src/main.c
+++ b/src/main.c
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
 		{ "disable-realtek-usb-fix", no_argument, NULL, 21 },
 		{ "a2dp-force-mono", no_argument, NULL, 6 },
 		{ "a2dp-force-audio-cd", no_argument, NULL, 7 },
-		{ "a2dp-volume", no_argument, NULL, 9 },
+		{ "native-volume", no_argument, NULL, 9 },
 		{ "sbc-quality", required_argument, NULL, 14 },
 #if ENABLE_AAC
 		{ "aac-afterburner", no_argument, NULL, 4 },
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
 					"  --disable-realtek-usb-fix\tdisable fix for mSBC on Realtek USB\n"
 					"  --a2dp-force-mono\t\ttry to force monophonic sound\n"
 					"  --a2dp-force-audio-cd\t\ttry to force 44.1 kHz sampling\n"
-					"  --a2dp-volume\t\t\tnative volume control by default\n"
+					"  --native-volume\t\t\tnative volume control by default\n"
 					"  --sbc-quality=MODE\t\tset SBC encoder quality mode\n"
 #if ENABLE_AAC
 					"  --aac-afterburner\t\tenable FDK AAC afterburner\n"
@@ -404,8 +404,9 @@ int main(int argc, char **argv) {
 		case 7 /* --a2dp-force-audio-cd */ :
 			config.a2dp.force_44100 = true;
 			break;
-		case 9 /* --a2dp-volume */ :
+		case 9 /* --native-volume */ :
 			config.a2dp.volume = true;
+			config.hfp.volume = true;
 			break;
 
 		case 14 /* --sbc-quality=MODE */ : {


### PR DESCRIPTION
When using soft volume, the sco volume cannot be adjusted, while it is normal in a2dp mode, so rename --a2dp-volume to --native-volume, and both a2dp/sco profiles can use it.