### PR TITLE
bluealsa-aplay: option to select volume mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ unreleased
 - codec-specific delay adjustment with ALSA control and persistency
 - fix for SBC codec and audio scaling on big-endian platforms
 - fix mSBC decode for MTU > 60 bytes (e.g. Realtek USB adapters)
+- bluealsa-aplay: option to auto-select volume mode for used PCM
 
 bluez-alsa v4.1.1 (2023-06-24)
 ==============================

--- a/misc/bash-completion/bluealsa
+++ b/misc/bash-completion/bluealsa
@@ -265,6 +265,11 @@ _bluealsa_aplay() {
 			__ltrim_colon_completions "$cur"
 			return
 			;;
+		--volume)
+			readarray -t list < <(_bluealsa_enum_values "$1" "$prev")
+			readarray -t COMPREPLY < <(compgen -W "${list[*]}" -- "$cur")
+			return
+			;;
 		--*)
 			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
 			;;

--- a/test/test-utils-aplay.c
+++ b/test/test-utils-aplay.c
@@ -242,6 +242,7 @@ CK_START_TEST(test_play_mixer_setup) {
 	ck_assert_int_ne(spawn_bluealsa_aplay(&sp_ba_aplay,
 				"--profile-sco",
 				"--pcm=bluealsa:PROFILE=sco",
+				"--volume=mixer",
 				"--mixer-device=bluealsa:DEV=23:45:67:89:AB:CD",
 				"--mixer-name=SCO",
 				"-v",

--- a/utils/aplay/Makefile.am
+++ b/utils/aplay/Makefile.am
@@ -10,6 +10,7 @@ bluealsa_aplay_SOURCES = \
 	../../src/shared/dbus-client.c \
 	../../src/shared/ffb.c \
 	../../src/shared/log.c \
+	../../src/shared/nv.c \
 	alsa-mixer.c \
 	alsa-pcm.c \
 	dbus.c \


### PR DESCRIPTION
A proposal to improve `bluealsa-aplay` volume control. Inspired by the discussion in PR #662, this proposal gives the `bluealsa-aplay` utility the ability to select soft volume or pass-through volume control independently of the `bluealsa` service defaults.

Default behavior remains unchanged, so backwards compatibility for existing installations is maintained.

See the changes to `doc/bluealsa-aplay.1.rst` for details of the new command-line option and the various new behaviors made available.