### PR TITLE
Alsa plugin resilience

### DIFF
--- a/.github/spellcheck-wordlist.txt
+++ b/.github/spellcheck-wordlist.txt
@@ -146,6 +146,7 @@ dpsnk
 dpsrc
 DYN
 EAGAIN
+EINTR
 EINVAL
 ENODEV
 EP

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -898,7 +898,7 @@ static int bluealsa_pause(snd_pcm_ioplug_t *io, int enable) {
 	}
 
 	if (!bluealsa_dbus_pcm_ctrl_send(pcm->ba_pcm_ctrl_fd,
-				enable ? "Pause" : "Resume", NULL))
+				enable ? "Pause" : "Resume", 200, NULL))
 		return -EIO;
 
 	if (enable == 0)

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -395,7 +395,7 @@ static int bluealsa_start(snd_pcm_ioplug_t *io) {
 
 	if (!bluealsa_dbus_pcm_ctrl_send_resume(pcm->ba_pcm_ctrl_fd, NULL)) {
 		debug2("Couldn't start PCM: %s", strerror(errno));
-		return -errno;
+		return -EIO;
 	}
 
 	/* Initialize delay calculation - capture reception begins immediately,
@@ -410,7 +410,7 @@ static int bluealsa_start(snd_pcm_ioplug_t *io) {
 					PTHREAD_FUNC(io_thread), io)) != 0) {
 		debug2("Couldn't create IO thread: %s", strerror(errno));
 		pcm->io_started = false;
-		return -errno;
+		return -EIO;
 	}
 
 	pthread_setname_np(pcm->io_thread, "pcm-io");
@@ -432,7 +432,7 @@ static int bluealsa_stop(snd_pcm_ioplug_t *io) {
 	pcm->io_hw_ptr = 0;
 
 	if (!bluealsa_dbus_pcm_ctrl_send_drop(pcm->ba_pcm_ctrl_fd, NULL))
-		return -errno;
+		return -EIO;
 
 	/* Applications that call poll() after snd_pcm_drain() will be blocked
 	 * forever unless we generate a poll() event here. */
@@ -899,7 +899,7 @@ static int bluealsa_pause(snd_pcm_ioplug_t *io, int enable) {
 
 	if (!bluealsa_dbus_pcm_ctrl_send(pcm->ba_pcm_ctrl_fd,
 				enable ? "Pause" : "Resume", NULL))
-		return -errno;
+		return -EIO;
 
 	if (enable == 0)
 		pthread_kill(pcm->io_thread, SIGIO);

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -705,7 +705,7 @@ static int bluealsa_drain(snd_pcm_ioplug_t *io) {
 	}
 
 	/* For a non-blocking drain, we do not wait for the drain to complete. */
-	if (io->nonblock == 1)
+	if (io->nonblock)
 		return -EAGAIN;
 
 	struct pollfd pfd = { pcm->event_fd, POLLIN, 0 };

--- a/src/shared/dbus-client.c
+++ b/src/shared/dbus-client.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/param.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include "shared/a2dp-codecs.h"
@@ -1009,7 +1010,7 @@ dbus_bool_t bluealsa_dbus_pcm_ctrl_send(
 		DBusError *error) {
 
 	ssize_t len = strlen(command);
-	if (write(fd_pcm_ctrl, command, len) == -1) {
+	if (send(fd_pcm_ctrl, command, len, MSG_NOSIGNAL) == -1) {
 		dbus_set_error(error, DBUS_ERROR_FAILED, "Write: %s", strerror(errno));
 		return FALSE;
 	}

--- a/src/shared/dbus-client.h
+++ b/src/shared/dbus-client.h
@@ -317,19 +317,20 @@ dbus_bool_t bluealsa_dbus_pcm_update(
 dbus_bool_t bluealsa_dbus_pcm_ctrl_send(
 		int fd_pcm_ctrl,
 		const char *command,
+		int timeout,
 		DBusError *error);
 
 #define bluealsa_dbus_pcm_ctrl_send_drain(fd, err) \
-	bluealsa_dbus_pcm_ctrl_send(fd, "Drain", err)
+	bluealsa_dbus_pcm_ctrl_send(fd, "Drain", 3000, err)
 
 #define bluealsa_dbus_pcm_ctrl_send_drop(fd, err) \
-	bluealsa_dbus_pcm_ctrl_send(fd, "Drop", err)
+	bluealsa_dbus_pcm_ctrl_send(fd, "Drop", 200, err)
 
 #define bluealsa_dbus_pcm_ctrl_send_pause(fd, err) \
-	bluealsa_dbus_pcm_ctrl_send(fd, "Pause", err)
+	bluealsa_dbus_pcm_ctrl_send(fd, "Pause", 200, err)
 
 #define bluealsa_dbus_pcm_ctrl_send_resume(fd, err) \
-	bluealsa_dbus_pcm_ctrl_send(fd, "Resume", err)
+	bluealsa_dbus_pcm_ctrl_send(fd, "Resume", 200, err)
 
 dbus_bool_t bluealsa_dbus_message_iter_array_get_strings(
 		DBusMessageIter *iter,

--- a/test/test-dbus.c
+++ b/test/test-dbus.c
@@ -249,6 +249,7 @@ CK_START_TEST(test_g_dbus_connection_emit_properties_changed) {
 
 	g_variant_builder_clear(&props);
 	test_dbus_connection_free(tc);
+	sync_barrier_free(&sb);
 
 } CK_END_TEST
 


### PR DESCRIPTION
Some more tweaks to the PCM plugin to help isolate it from failures in the server.
Also includes a fix for a D-Bus test failure (but it seems there is still at least one other bug in there that causes occasional failures in github actions).