### PR TITLE
Add support for libfreeaptx

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,6 +21,7 @@ jobs:
         - --enable-faststream --enable-mp3lame
         - --enable-aplay --enable-ofono --enable-upower
         - --enable-cli --enable-rfcomm --enable-manpages
+        - --enable-aptx --enable-aptx-hd --with-libopenaptx
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:
@@ -36,6 +37,7 @@ jobs:
           libglib2.0-dev
           libmp3lame-dev
           libmpg123-dev
+          libopenaptx-dev
           libreadline-dev
           libsbc-dev
           libspandsp-dev
@@ -120,6 +122,7 @@ jobs:
           libglib2.0-dev
           libmp3lame-dev
           libmpg123-dev
+          libopenaptx-dev
           libsbc-dev
           libspandsp-dev
     - uses: actions/checkout@v4
@@ -132,6 +135,9 @@ jobs:
       run: |
         ${{ github.workspace }}/configure \
           --enable-aac \
+          --enable-aptx \
+          --enable-aptx-hd \
+          --with-libopenaptx \
           --enable-faststream \
           --enable-mp3lame \
           --enable-mpg123 \

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -41,6 +41,7 @@ jobs:
           libglib2.0-dev
           libmp3lame-dev
           libmpg123-dev
+          libopenaptx-dev
           libncurses5-dev
           libreadline-dev
           libsbc-dev
@@ -60,6 +61,9 @@ jobs:
       run: |
         ${{ github.workspace }}/configure \
           --enable-aac \
+          --enable-aptx \
+          --enable-aptx-hd \
+          --with-libopenaptx \
           --enable-faststream \
           --enable-mp3lame \
           --enable-mpg123 \
@@ -106,6 +110,7 @@ jobs:
           libglib2.0-dev
           libmp3lame-dev
           libmpg123-dev
+          libopenaptx-dev
           libncurses5-dev
           libreadline-dev
           libsbc-dev
@@ -119,9 +124,12 @@ jobs:
       working-directory: ${{ github.workspace }}/build
       run: |
         ${{ github.workspace }}/configure \
-          --enable-aac \
           --enable-debug \
           --enable-debug-time \
+          --enable-aac \
+          --enable-aptx \
+          --enable-aptx-hd \
+          --with-libopenaptx \
           --enable-faststream \
           --enable-mp3lame \
           --enable-mpg123 \

--- a/.github/workflows/codecov-report.yaml
+++ b/.github/workflows/codecov-report.yaml
@@ -27,6 +27,7 @@ jobs:
           libglib2.0-dev
           libmp3lame-dev
           libmpg123-dev
+          libopenaptx-dev
           libsbc-dev
           libspandsp-dev
     - uses: actions/checkout@v4
@@ -39,6 +40,9 @@ jobs:
       run: |
         ${{ github.workspace }}/configure \
           --enable-aac \
+          --enable-aptx \
+          --enable-aptx-hd \
+          --with-libopenaptx \
           --enable-faststream \
           --enable-mp3lame \
           --enable-mpg123 \

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ unreleased
 - fix for SBC codec and audio scaling on big-endian platforms
 - fix mSBC decode for MTU > 60 bytes (e.g. Realtek USB adapters)
 - bluealsa-aplay: option to auto-select volume mode for used PCM
+- support use of libfreeaptx for apt-X and apt-X HD codecs
 
 bluez-alsa v4.1.1 (2023-06-24)
 ==============================

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,20 @@ AC_ARG_WITH([libopenaptx],
 	[AS_HELP_STRING([--with-libopenaptx], [use libopenaptx by pali.rohar for apt-X (HD)])])
 AM_CONDITIONAL([WITH_LIBOPENAPTX], [test "x$with_libopenaptx" = "xyes"])
 
+AC_ARG_WITH([libfreeaptx],
+	[AS_HELP_STRING([--with-libfreeaptx], [use libfreeaptx for apt-X (HD)])])
+AM_CONDITIONAL([WITH_LIBFREEAPTX], [test "x$with_libfreeaptx" = "xyes"])
+
+# one of libopenaptx or libfreeaptx have been selected
+AM_CONDITIONAL([WITH_lIBOPENAPTX_OR_WITH_LIBFREEAPTX],
+	[test "x$with_libopenaptx" = "xyes" -o "x$with_libfreeaptx" = "xyes"])
+
+# both libopenaptx and libfreeaptx have been selected
+AM_CONDITIONAL([WITH_lIBOPENAPTX_AND_WITH_LIBFREEAPTX],
+	[test "x$with_libopenaptx" = "xyes" -a "x$with_libfreeaptx" = "xyes"])
+AM_COND_IF([WITH_lIBOPENAPTX_AND_WITH_LIBFREEAPTX],
+	[AC_MSG_ERROR([select at most one of libopenaptx or libfreeaptx])])
+
 AC_ARG_ENABLE([aptx],
 	[AS_HELP_STRING([--enable-aptx], [enable apt-X support])])
 AM_CONDITIONAL([ENABLE_APTX], [test "x$enable_aptx" = "xyes"])
@@ -122,10 +136,16 @@ AM_COND_IF([ENABLE_APTX], [
 		AC_DEFINE([HAVE_APTX_DECODE], [1], [Define to 1 if you have apt-X decode library.])
 		AC_DEFINE([WITH_LIBOPENAPTX], [1], [Define to 1 if libopenaptx shall be used.])
 	], [
-		PKG_CHECK_MODULES([APTX], [openaptx >= 1.2.0])
-		if test "$($PKG_CONFIG --variable=aptxdecoder openaptx)" = "true"; then
+		AM_COND_IF([WITH_LIBFREEAPTX], [
+			PKG_CHECK_MODULES([APTX], [libfreeaptx >= 0.1.1])
 			AC_DEFINE([HAVE_APTX_DECODE], [1], [Define to 1 if you have apt-X decode library.])
-		fi
+			AC_DEFINE([WITH_LIBFREEAPTX], [1], [Define to 1 if libfreeaptx shall be used.])
+		], [
+			PKG_CHECK_MODULES([APTX], [openaptx >= 1.2.0])
+			if test "$($PKG_CONFIG --variable=aptxdecoder openaptx)" = "true"; then
+				AC_DEFINE([HAVE_APTX_DECODE], [1], [Define to 1 if you have apt-X decode library.])
+			fi
+		])
 	])
 	AC_DEFINE([ENABLE_APTX], [1], [Define to 1 if apt-X is enabled.])
 ])
@@ -139,10 +159,16 @@ AM_COND_IF([ENABLE_APTX_HD], [
 		AC_DEFINE([HAVE_APTX_HD_DECODE], [1], [Define to 1 if you have apt-X HD decode library.])
 		AC_DEFINE([WITH_LIBOPENAPTX], [1], [Define to 1 if libopenaptx shall be used.])
 	], [
-		PKG_CHECK_MODULES([APTX_HD], [openaptxhd >= 1.2.0])
-		if test "$($PKG_CONFIG --variable=aptxdecoder openaptxhd)" = "true"; then
+		AM_COND_IF([WITH_LIBFREEAPTX], [
+			PKG_CHECK_MODULES([APTX_HD], [libfreeaptx >= 0.1.1])
 			AC_DEFINE([HAVE_APTX_HD_DECODE], [1], [Define to 1 if you have apt-X HD decode library.])
-		fi
+			AC_DEFINE([WITH_LIBFREEAPTX], [1], [Define to 1 if libfreeaptx shall be used.])
+		], [
+			PKG_CHECK_MODULES([APTX], [openaptx >= 1.2.0])
+			if test "$($PKG_CONFIG --variable=aptxdecoder openaptxhd)" = "true"; then
+				AC_DEFINE([HAVE_APTX_HD_DECODE], [1], [Define to 1 if you have apt-X HD decode library.])
+			fi
+		])
 	])
 	AC_DEFINE([ENABLE_APTX_HD], [1], [Define to 1 if apt-X HD is enabled.])
 ])
@@ -407,12 +433,13 @@ AM_COND_IF([ALSA_1_1_2__1_1_3], [
 	AC_MSG_WARN([LIBASOUND_THREAD_SAFE=0 while using bluealsa PCM.])
 ])
 
-# notify user that using libopenaptx might be a good idea
+# notify user that using libopenaptx or libfreeaptx might be a good idea
 AM_COND_IF([ENABLE_APTX_OR_APTX_HD], [
-AM_COND_IF([WITH_LIBOPENAPTX], [], [
+AM_COND_IF([WITH_lIBOPENAPTX_OR_WITH_LIBFREEAPTX], [], [
 	AC_MSG_NOTICE([       *** using apt-X (HD) via Qualcomm API ***])
 	AC_MSG_NOTICE([Enabled apt-X (HD) support requires encoder (and decoder)])
 	AC_MSG_NOTICE([library with a proprietary Qualcomm API. Please consider])
-	AC_MSG_NOTICE([using --with-libopenaptx option which will use a library])
-	AC_MSG_NOTICE([based on FFmpeg project with better decoding support.])
+	AC_MSG_NOTICE([using --with-libopenaptx or --with-libfreeaptx option])
+	AC_MSG_NOTICE([which will use a library based on FFmpeg project with])
+	AC_MSG_NOTICE([better decoding support.])
 ])])

--- a/src/a2dp-aptx.c
+++ b/src/a2dp-aptx.c
@@ -16,7 +16,6 @@
 
 #include <errno.h>
 #include <pthread.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Some distributions now package libfreeaptx for apt-X support (because pipewire uses it rather than libopenaptx). It appears that Fedora has **only** libfreeaptx, whereas Debian includes both libopenaptx and libfreeaptx.

See #678 for more information.