### PR TITLE
Use basename implementation from glib-2.0

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -276,8 +276,7 @@ int main(int argc, char **argv) {
 			syslog = true;
 			break;
 		}
-
-	log_open(basename(argv[0]), syslog);
+	log_open(g_path_get_basename(argv[0]), syslog);
 
 	if (ba_config_init() != 0) {
 		error("Couldn't initialize bluealsa config");

--- a/test/mock/mock.c
+++ b/test/mock/mock.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
 			return EXIT_FAILURE;
 		}
 
-	log_open(basename(argv[0]), false);
+	log_open(g_path_get_basename(argv[0]), false);
 	assert(ba_config_init() == 0);
 
 	/* Add BT address to the HCI filter to test filtering logic. */

--- a/utils/aplay/Makefile.am
+++ b/utils/aplay/Makefile.am
@@ -22,12 +22,14 @@ bluealsa_aplay_CFLAGS = \
 	@ALSA_CFLAGS@ \
 	@BLUEZ_CFLAGS@ \
 	@DBUS1_CFLAGS@ \
+	@GLIB2_CFLAGS@ \
 	@LIBUNWIND_CFLAGS@
 
 bluealsa_aplay_LDADD = \
 	@ALSA_LIBS@ \
 	@BLUEZ_LIBS@ \
 	@DBUS1_LIBS@ \
+	@GLIB2_LIBS@ \
 	@LIBUNWIND_LIBS@
 
 endif

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -32,6 +32,7 @@
 #include <alsa/asoundlib.h>
 #include <bluetooth/bluetooth.h>
 #include <dbus/dbus.h>
+#include <glib.h>
 
 #include "shared/dbus-client.h"
 #include "shared/dbus-client-pcm.h"
@@ -1105,7 +1106,7 @@ int main(int argc, char *argv[]) {
 			break;
 		}
 
-	log_open(basename(argv[0]), syslog);
+	log_open(g_path_get_basename(argv[0]), syslog);
 	dbus_threads_init_default();
 
 	/* parse options */

--- a/utils/cli/Makefile.am
+++ b/utils/cli/Makefile.am
@@ -27,10 +27,12 @@ bluealsa_cli_SOURCES = \
 bluealsa_cli_CFLAGS = \
 	-I$(top_srcdir)/src \
 	@DBUS1_CFLAGS@ \
+	@GLIB2_CFLAGS@ \
 	@LIBUNWIND_CFLAGS@
 
 bluealsa_cli_LDADD = \
 	@DBUS1_LIBS@ \
+	@GLIB2_LIBS@ \
 	@LIBUNWIND_LIBS@
 
 endif

--- a/utils/cli/cli.c
+++ b/utils/cli/cli.c
@@ -22,6 +22,7 @@
 #include <strings.h>
 #include <sys/param.h>
 
+#include <glib.h>
 #include <dbus/dbus.h>
 
 #include "cli.h"
@@ -414,7 +415,7 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	log_open(basename(argv[0]), false);
+	log_open(g_path_get_basename(argv[0]), false);
 	dbus_threads_init_default();
 
 	DBusError err = DBUS_ERROR_INIT;

--- a/utils/rfcomm/Makefile.am
+++ b/utils/rfcomm/Makefile.am
@@ -16,10 +16,12 @@ bluealsa_rfcomm_CFLAGS = \
 	-I$(top_srcdir)/src \
 	@BLUEZ_CFLAGS@ \
 	@DBUS1_CFLAGS@ \
+	@GLIB2_CFLAGS@ \
 	@LIBUNWIND_CFLAGS@
 
 bluealsa_rfcomm_LDADD = \
 	@DBUS1_LIBS@ \
+	@GLIB2_LIBS@ \
 	@LIBUNWIND_LIBS@ \
 	-lreadline
 

--- a/utils/rfcomm/rfcomm.c
+++ b/utils/rfcomm/rfcomm.c
@@ -25,6 +25,7 @@
 
 #include <bluetooth/bluetooth.h>
 #include <dbus/dbus.h>
+#include <glib.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 
@@ -134,7 +135,7 @@ int main(int argc, char *argv[]) {
 
 	char dbus_ba_service[32] = BLUEALSA_SERVICE;
 
-	log_open(basename(argv[0]), false);
+	log_open(g_path_get_basename(argv[0]), false);
 
 	while ((opt = getopt_long(argc, argv, opts, longopts, NULL)) != -1)
 		switch (opt) {


### PR DESCRIPTION
This is portable across various platforms and system C libraries e.g. basename differs between glibc and musl, where glibc provides a GNU implementation and POSIX version, and musl provides posix version only and Newer version of musl have removed prototype for basename in string.h [1] which caused build failures with gcc-14 on musl systems.

g_path_get_basename() is implemented in glib-2.0 and is portable across these systems. It allocates a new string for the returned value which should be free'd by user, however, all our usecases here are in main() functions, so technically we are not going to leak any memory.

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7


