### PR TITLE
Fix potential temporary deadlock in A2DP codec selection procedure.

### DIFF
--- a/src/ba-rfcomm.c
+++ b/src/ba-rfcomm.c
@@ -138,9 +138,9 @@ static void rfcomm_set_hfp_state(struct ba_rfcomm *r, enum hfp_slc_state state) 
  * Finalize HFP codec selection - signal other threads. */
 static void rfcomm_finalize_codec_selection(struct ba_rfcomm *r) {
 
-	pthread_mutex_lock(&r->sco->codec_id_mtx);
+	pthread_mutex_lock(&r->sco->codec_select_client_mtx);
 	r->codec_selection_done = true;
-	pthread_mutex_unlock(&r->sco->codec_id_mtx);
+	pthread_mutex_unlock(&r->sco->codec_select_client_mtx);
 
 	pthread_cond_signal(&r->codec_selection_cond);
 

--- a/test/test-rfcomm.c
+++ b/test/test-rfcomm.c
@@ -187,10 +187,12 @@ CK_START_TEST(test_rfcomm_hsp_hs) {
 #if ENABLE_HFP_CODEC_SELECTION
 static void *test_rfcomm_hfp_ag_switch_codecs(void *userdata) {
 	struct ba_transport *sco = userdata;
-	/* the test code rejects first codec selection request for mSBC */
+	pthread_mutex_lock(&sco->codec_select_client_mtx);
 	ck_assert_int_eq(ba_transport_select_codec_sco(sco, HFP_CODEC_CVSD), 0);
+	/* The test code rejects first codec selection request for mSBC. */
 	ck_assert_int_eq(ba_transport_select_codec_sco(sco, HFP_CODEC_MSBC), -1);
 	ck_assert_int_eq(ba_transport_select_codec_sco(sco, HFP_CODEC_MSBC), 0);
+	pthread_mutex_unlock(&sco->codec_select_client_mtx);
 	return NULL;
 }
 #endif


### PR DESCRIPTION
If a dbus client thread locks the codec_id_mtx mutex while Bluez is processing a SetConfiguration request, then that can lead to the main thread being blocked if a client calls any method that needs to read the current codec. However, the SetConfiguration request needs the main thread to be active to respond to the ClearConfiguration call that Bluez makes during its own handling of SetConfiguration. So there is a risk of deadlock if the client attempts to read the codec id while SetConfiguration is in progress. This deadlock is temporary because the dbus calls have a timeout - but Bluez handles the timeout by closing the A2DP profile connection.

There does not appear to be any clear reason why SetConfiguration needs to lock the client_id_mtx mutex, since it does not actually modify the transport codec_id (a new transport instance is created with the new codec_id instead). So this commit avoids this deadlock simpling by removing the codec_id_mtx mutex lock from ba_transport_select_codec_a2dp().

Fixes #725

> Please have a good description of the problem and the fix. Help the reviewer
> understand what to expect.
>
> For new feature, extensive change or non-trivial bug fix add a simple unit
> test or at least describe how to test the code manually.
>
> If you have an issue number, please reference it with a syntax `Fixes #123`.
>
> Please delete instructions prefixed with '>' to prove you have read them.
