### PR TITLE
Enable dbus delay signals for internal processing delay.

### DIFF
--- a/doc/a2dpconf.1.rst
+++ b/doc/a2dpconf.1.rst
@@ -36,7 +36,7 @@ OPTIONS
     Print version and exit.
 
 -v, --verbose
-    Sow verbose bit-stream details.
+    Show verbose bit-stream details.
     Display each field as a binary mask with each bit represented by a single
     character.
 

--- a/src/a2dp-aac.c
+++ b/src/a2dp-aac.c
@@ -30,6 +30,7 @@
 #include "ba-config.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "io.h"
 #include "rtp.h"
 #include "utils.h"
@@ -290,6 +291,7 @@ void *a2dp_aac_enc_thread(struct ba_transport_pcm *t_pcm) {
 
 	/* Get the delay introduced by the encoder. */
 	t_pcm->codec_delay_dms = info.nDelay * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	rtp_header_t *rtp_header;
 	/* initialize RTP header and get anchor for payload */
@@ -377,6 +379,7 @@ void *a2dp_aac_enc_thread(struct ba_transport_pcm *t_pcm) {
 					if (!io.initiated) {
 						/* Get the delay due to codec processing. */
 						t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+						ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 						io.initiated = true;
 					}
 
@@ -556,6 +559,7 @@ void *a2dp_aac_dec_thread(struct ba_transport_pcm *t_pcm) {
 
 			/* Update the delay introduced by the decoder. */
 			t_pcm->codec_delay_dms = info->outputDelay * 10000 / rate;
+			ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 			/* update local state with decoded PCM frames */
 			rtp_state_update(&rtp, info->frameSize);

--- a/src/a2dp-aptx-hd.c
+++ b/src/a2dp-aptx-hd.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-aptx-hd.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -205,14 +205,17 @@ void *a2dp_aptx_hd_enc_thread(struct ba_transport_pcm *t_pcm) {
 				goto fail;
 			}
 
+			if (!io.initiated) {
+				/* Get the delay due to codec processing. */
+				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				io.initiated = true;
+			}
+
 			unsigned int pcm_frames = pcm_samples / channels;
-			/* keep data transfer at a constant bit rate */
+			/* Keep data transfer at a constant bit rate. */
 			asrsync_sync(&io.asrs, pcm_frames);
 			/* move forward RTP timestamp clock */
 			rtp.ts_pcm_frames += pcm_frames;
-
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 			/* reinitialize output buffer */
 			ffb_rewind(&bt);

--- a/src/a2dp-aptx-hd.c
+++ b/src/a2dp-aptx-hd.c
@@ -26,6 +26,7 @@
 #include "ba-config.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "codec-aptx.h"
 #include "io.h"
 #include "rtp.h"
@@ -208,6 +209,7 @@ void *a2dp_aptx_hd_enc_thread(struct ba_transport_pcm *t_pcm) {
 			if (!io.initiated) {
 				/* Get the delay due to codec processing. */
 				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 				io.initiated = true;
 			}
 

--- a/src/a2dp-aptx.c
+++ b/src/a2dp-aptx.c
@@ -26,6 +26,7 @@
 #include "ba-config.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "codec-aptx.h"
 #include "io.h"
 #include "shared/a2dp-codecs.h"
@@ -193,6 +194,7 @@ void *a2dp_aptx_enc_thread(struct ba_transport_pcm *t_pcm) {
 			if (!io.initiated) {
 				/* Get the delay due to codec processing. */
 				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 				io.initiated = true;
 			}
 

--- a/src/a2dp-aptx.c
+++ b/src/a2dp-aptx.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-aptx.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -16,6 +16,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -189,11 +190,14 @@ void *a2dp_aptx_enc_thread(struct ba_transport_pcm *t_pcm) {
 				goto fail;
 			}
 
-			/* keep data transfer at a constant bit rate */
-			asrsync_sync(&io.asrs, pcm_samples / channels);
+			if (!io.initiated) {
+				/* Get the delay due to codec processing. */
+				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				io.initiated = true;
+			}
 
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
+			/* Keep data transfer at a constant bit rate. */
+			asrsync_sync(&io.asrs, pcm_samples / channels);
 
 			/* reinitialize output buffer */
 			ffb_rewind(&bt);

--- a/src/a2dp-faststream.c
+++ b/src/a2dp-faststream.c
@@ -24,6 +24,7 @@
 #include "ba-config.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "codec-sbc.h"
 #include "io.h"
 #include "shared/a2dp-codecs.h"
@@ -156,6 +157,7 @@ void *a2dp_fs_enc_thread(struct ba_transport_pcm *t_pcm) {
 	const unsigned int sbc_delay_frames = 73;
 	/* Get the total delay introduced by the codec. */
 	t_pcm->codec_delay_dms = sbc_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	debug_transport_pcm_thread_loop(t_pcm, "START");
 	for (ba_transport_pcm_state_set_running(t_pcm);;) {
@@ -216,6 +218,7 @@ void *a2dp_fs_enc_thread(struct ba_transport_pcm *t_pcm) {
 			if (!io.initiated) {
 				/* Get the delay due to codec processing. */
 				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 				io.initiated = true;
 			}
 

--- a/src/a2dp-faststream.c
+++ b/src/a2dp-faststream.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-faststream.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -213,14 +213,17 @@ void *a2dp_fs_enc_thread(struct ba_transport_pcm *t_pcm) {
 				goto fail;
 			}
 
+			if (!io.initiated) {
+				/* Get the delay due to codec processing. */
+				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				io.initiated = true;
+			}
+
 			/* make room for new FastStream frames */
 			ffb_rewind(&bt);
 
-			/* keep data transfer at a constant bit rate */
+			/* Keep data transfer at a constant bit rate. */
 			asrsync_sync(&io.asrs, pcm_frames);
-
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 			/* If the input buffer was not consumed (due to codesize limit), we
 			 * have to append new data to the existing one. Since we do not use

--- a/src/a2dp-lc3plus.c
+++ b/src/a2dp-lc3plus.c
@@ -30,6 +30,7 @@
 #include "ba-config.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "io.h"
 #include "rtp.h"
 #include "utils.h"
@@ -253,6 +254,7 @@ void *a2dp_lc3plus_enc_thread(struct ba_transport_pcm *t_pcm) {
 	 * delay in the decoder thread. */
 	const int lc3plus_delay_frames = lc3plus_enc_get_delay(handle);
 	t_pcm->codec_delay_dms = lc3plus_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	rtp_header_t *rtp_header;
 	rtp_media_header_t *rtp_media_header;
@@ -356,6 +358,7 @@ void *a2dp_lc3plus_enc_thread(struct ba_transport_pcm *t_pcm) {
 				if (!io.initiated) {
 					/* Get the delay due to codec processing. */
 					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 					io.initiated = true;
 				}
 

--- a/src/a2dp-ldac.c
+++ b/src/a2dp-ldac.c
@@ -27,6 +27,7 @@
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
 #include "ba-config.h"
+#include "bluealsa-dbus.h"
 #include "io.h"
 #include "rtp.h"
 #include "utils.h"
@@ -169,6 +170,7 @@ void *a2dp_ldac_enc_thread(struct ba_transport_pcm *t_pcm) {
 	const unsigned int ldac_delay_frames = 128;
 	/* Get the total delay introduced by the codec. */
 	t_pcm->codec_delay_dms = ldac_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	rtp_header_t *rtp_header;
 	rtp_media_header_t *rtp_media_header;
@@ -247,6 +249,7 @@ void *a2dp_ldac_enc_thread(struct ba_transport_pcm *t_pcm) {
 				if (!io.initiated) {
 					/* Get the delay due to codec processing. */
 					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 					io.initiated = true;
 				}
 

--- a/src/a2dp-ldac.c
+++ b/src/a2dp-ldac.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-ldac.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -244,6 +244,12 @@ void *a2dp_ldac_enc_thread(struct ba_transport_pcm *t_pcm) {
 					goto fail;
 				}
 
+				if (!io.initiated) {
+					/* Get the delay due to codec processing. */
+					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					io.initiated = true;
+				}
+
 				if (errno == EAGAIN)
 					/* The io_bt_write() call was blocking due to not enough
 					 * space in the BT socket. Set the queued_bytes to some
@@ -256,13 +262,10 @@ void *a2dp_ldac_enc_thread(struct ba_transport_pcm *t_pcm) {
 			}
 
 			unsigned int pcm_frames = pcm_samples / channels;
-			/* keep data transfer at a constant bit rate */
+			/* Keep data transfer at a constant bit rate. */
 			asrsync_sync(&io.asrs, pcm_frames);
 			/* move forward RTP timestamp clock */
 			rtp_state_update(&rtp, pcm_frames);
-
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 		}
 

--- a/src/a2dp-lhdc.c
+++ b/src/a2dp-lhdc.c
@@ -29,6 +29,7 @@
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
 #include "ba-config.h"
+#include "bluealsa-dbus.h"
 #include "io.h"
 #include "rtp.h"
 #include "utils.h"
@@ -197,6 +198,7 @@ void *a2dp_lhdc_enc_thread(struct ba_transport_pcm *t_pcm) {
 	const unsigned int ldac_delay_frames = 1024;
 	/* Get the total delay introduced by the codec. */
 	t_pcm->codec_delay_dms = ldac_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	rtp_header_t *rtp_header;
 	rtp_lhdc_media_header_t *rtp_lhdc_media_header;
@@ -278,6 +280,7 @@ void *a2dp_lhdc_enc_thread(struct ba_transport_pcm *t_pcm) {
 				if (!io.initiated) {
 					/* Get the delay due to codec processing. */
 					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 					io.initiated = true;
 				}
 

--- a/src/a2dp-lhdc.c
+++ b/src/a2dp-lhdc.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-lhdc.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  * Copyright (c) 2023      anonymix007
  *
  * This file is a part of bluez-alsa.
@@ -275,6 +275,12 @@ void *a2dp_lhdc_enc_thread(struct ba_transport_pcm *t_pcm) {
 					goto fail;
 				}
 
+				if (!io.initiated) {
+					/* Get the delay due to codec processing. */
+					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					io.initiated = true;
+				}
+
 				if (errno == EAGAIN)
 					/* The io_bt_write() call was blocking due to not enough
 					 * space in the BT socket. Set the queued_bytes to some
@@ -287,13 +293,10 @@ void *a2dp_lhdc_enc_thread(struct ba_transport_pcm *t_pcm) {
 			}
 
 			unsigned int pcm_frames = lhdc_pcm_samples / channels;
-			/* keep data transfer at a constant bit rate */
+			/* Keep data transfer at a constant bit rate. */
 			asrsync_sync(&io.asrs, pcm_frames);
 			/* move forward RTP timestamp clock */
 			rtp_state_update(&rtp, pcm_frames);
-
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 		}
 

--- a/src/a2dp-mpeg.c
+++ b/src/a2dp-mpeg.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-mpeg.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -294,6 +294,12 @@ void *a2dp_mp3_enc_thread(struct ba_transport_pcm *t_pcm) {
 					goto fail;
 				}
 
+				if (!io.initiated) {
+					/* Get the delay due to codec processing. */
+					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					io.initiated = true;
+				}
+
 				/* account written payload only */
 				len -= RTP_HEADER_LEN + sizeof(*rtp_mpeg_audio_header);
 
@@ -309,13 +315,10 @@ void *a2dp_mp3_enc_thread(struct ba_transport_pcm *t_pcm) {
 
 		}
 
-		/* keep data transfer at a constant bit rate */
+		/* Keep data transfer at a constant bit rate. */
 		asrsync_sync(&io.asrs, pcm_frames);
 		/* move forward RTP timestamp clock */
 		rtp_state_update(&rtp, pcm_frames);
-
-		/* update busy delay (encoding overhead) */
-		t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 		/* If the input buffer was not consumed (due to frame alignment), we
 		 * have to append new data to the existing one. Since we do not use

--- a/src/a2dp-mpeg.c
+++ b/src/a2dp-mpeg.c
@@ -35,6 +35,7 @@
 #include "ba-config.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "io.h"
 #include "rtp.h"
 #include "utils.h"
@@ -229,6 +230,7 @@ void *a2dp_mp3_enc_thread(struct ba_transport_pcm *t_pcm) {
 	/* Get the total delay introduced by the codec. */
 	const int mpeg_delay_frames = lame_get_encoder_delay(handle);
 	t_pcm->codec_delay_dms = mpeg_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	rtp_header_t *rtp_header;
 	rtp_mpeg_audio_header_t *rtp_mpeg_audio_header;
@@ -297,6 +299,7 @@ void *a2dp_mp3_enc_thread(struct ba_transport_pcm *t_pcm) {
 				if (!io.initiated) {
 					/* Get the delay due to codec processing. */
 					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 					io.initiated = true;
 				}
 

--- a/src/a2dp-opus.c
+++ b/src/a2dp-opus.c
@@ -28,6 +28,7 @@
 #include "ba-config.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "io.h"
 #include "rtp.h"
 #include "shared/a2dp-codecs.h"
@@ -172,6 +173,7 @@ void *a2dp_opus_enc_thread(struct ba_transport_pcm *t_pcm) {
 	/* Get the delay introduced by the encoder. */
 	opus_encoder_ctl(opus, OPUS_GET_LOOKAHEAD(&opus_delay_frames));
 	t_pcm->codec_delay_dms = opus_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	rtp_header_t *rtp_header;
 	rtp_media_header_t *rtp_media_header;
@@ -233,6 +235,7 @@ void *a2dp_opus_enc_thread(struct ba_transport_pcm *t_pcm) {
 			if (!io.initiated) {
 				/* Get the delay due to codec processing. */
 				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 				io.initiated = true;
 			}
 
@@ -306,6 +309,7 @@ void *a2dp_opus_dec_thread(struct ba_transport_pcm *t_pcm) {
 	/* Get the delay introduced by the decoder. */
 	opus_decoder_ctl(opus, OPUS_GET_LOOKAHEAD(&opus_delay_frames));
 	t_pcm->codec_delay_dms = opus_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	struct rtp_state rtp = { .synced = false };
 	/* RTP clock frequency equal to PCM sample rate */

--- a/src/a2dp-opus.c
+++ b/src/a2dp-opus.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-opus.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -230,13 +230,16 @@ void *a2dp_opus_enc_thread(struct ba_transport_pcm *t_pcm) {
 				goto fail;
 			}
 
-			/* keep data transfer at a constant bit rate */
+			if (!io.initiated) {
+				/* Get the delay due to codec processing. */
+				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				io.initiated = true;
+			}
+
+			/* Keep data transfer at a constant bit rate. */
 			asrsync_sync(&io.asrs, opus_frame_pcm_frames);
 			/* move forward RTP timestamp clock */
 			rtp_state_update(&rtp, opus_frame_pcm_frames);
-
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 			/* If the input buffer was not consumed (due to encoder frame
 			 * constraint), we have to append new data to the existing one.

--- a/src/a2dp-sbc.c
+++ b/src/a2dp-sbc.c
@@ -29,6 +29,7 @@
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
 #include "ba-config.h"
+#include "bluealsa-dbus.h"
 #include "codec-sbc.h"
 #include "io.h"
 #include "rtp.h"
@@ -180,6 +181,7 @@ void *a2dp_sbc_enc_thread(struct ba_transport_pcm *t_pcm) {
 	const unsigned int sbc_delay_frames = 73;
 	/* Get the total delay introduced by the codec. */
 	t_pcm->codec_delay_dms = sbc_delay_frames * 10000 / rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	rtp_header_t *rtp_header;
 	rtp_media_header_t *rtp_media_header;
@@ -267,6 +269,7 @@ void *a2dp_sbc_enc_thread(struct ba_transport_pcm *t_pcm) {
 				 * frame is written, the BT sink can start decoding and playing
 				 * audio in a continuous fashion. */
 				t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+				ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 				io.initiated = true;
 			}
 

--- a/src/ba-transport-pcm.h
+++ b/src/ba-transport-pcm.h
@@ -129,6 +129,9 @@ struct ba_transport_pcm {
 	 * the host computational power. It is used to compensate for the time
 	 * required to encode or decode audio. */
 	unsigned int processing_delay_dms;
+	/* The last reported total codec + processing delay. It is used to limit
+	 * the rate at which changes are reported via D-Bus. */
+	unsigned int reported_codec_delay_dms;
 	/* Positive (or negative) delay reported by the client. */
 	int client_delay_dms;
 

--- a/src/io.c
+++ b/src/io.c
@@ -347,6 +347,7 @@ repoll:
 		case BA_TRANSPORT_PCM_SIGNAL_OPEN:
 		case BA_TRANSPORT_PCM_SIGNAL_RESUME:
 			io->asrs.frames = 0;
+			io->initiated = false;
 			io->timeout = -1;
 			goto repoll;
 		case BA_TRANSPORT_PCM_SIGNAL_CLOSE:

--- a/src/io.h
+++ b/src/io.h
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - io.h
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -16,6 +16,7 @@
 # include <config.h>
 #endif
 
+#include <stdbool.h>
 #include <sys/types.h>
 
 #include "ba-transport-pcm.h"
@@ -30,6 +31,8 @@
 struct io_poll {
 	/* transfer bit rate synchronization */
 	struct asrsync asrs;
+	/* transfer has been initiated */
+	bool initiated;
 	/* keep-alive and sync timeout */
 	int timeout;
 };

--- a/src/sco-cvsd.c
+++ b/src/sco-cvsd.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - sco-cvsd.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -76,10 +76,8 @@ void *sco_cvsd_enc_thread(struct ba_transport_pcm *t_pcm) {
 			input += mtu_samples;
 			input_samples -= mtu_samples;
 
-			/* keep data transfer at a constant bit rate */
+			/* Keep data transfer at a constant bit rate. */
 			asrsync_sync(&io.asrs, mtu_samples);
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 		}
 

--- a/src/sco-lc3-swb.c
+++ b/src/sco-lc3-swb.c
@@ -23,6 +23,7 @@
 
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "codec-lc3-swb.h"
 #include "io.h"
 #include "shared/defs.h"
@@ -45,6 +46,7 @@ void *sco_lc3_swb_enc_thread(struct ba_transport_pcm *t_pcm) {
 	/* Get the total delay introduced by the codec. */
 	const ssize_t lc3_swb_delay_frames = lc3_swb_get_delay(&codec);
 	t_pcm->codec_delay_dms = lc3_swb_delay_frames * 10000 / t_pcm->rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	debug_transport_pcm_thread_loop(t_pcm, "START");
 	for (ba_transport_pcm_state_set_running(t_pcm);;) {
@@ -81,6 +83,7 @@ void *sco_lc3_swb_enc_thread(struct ba_transport_pcm *t_pcm) {
 				if (!io.initiated) {
 					/* Get the delay due to codec processing. */
 					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 					io.initiated = true;
 				}
 

--- a/src/sco-msbc.c
+++ b/src/sco-msbc.c
@@ -19,6 +19,7 @@
 
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
+#include "bluealsa-dbus.h"
 #include "codec-msbc.h"
 #include "io.h"
 #include "shared/defs.h"
@@ -46,6 +47,7 @@ void *sco_msbc_enc_thread(struct ba_transport_pcm *t_pcm) {
 	const unsigned int sbc_delay_frames = 73;
 	/* Get the total delay introduced by the codec. */
 	t_pcm->codec_delay_dms = sbc_delay_frames * 10000 / t_pcm->rate;
+	ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 
 	debug_transport_pcm_thread_loop(t_pcm, "START");
 	for (ba_transport_pcm_state_set_running(t_pcm);;) {
@@ -87,6 +89,7 @@ void *sco_msbc_enc_thread(struct ba_transport_pcm *t_pcm) {
 				if (!io.initiated) {
 					/* Get the delay due to codec processing. */
 					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					ba_transport_pcm_delay_sync(t_pcm, BA_DBUS_PCM_UPDATE_DELAY);
 					io.initiated = true;
 				}
 

--- a/src/sco-msbc.c
+++ b/src/sco-msbc.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - sco-msbc.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -84,15 +84,19 @@ void *sco_msbc_enc_thread(struct ba_transport_pcm *t_pcm) {
 					goto exit;
 				}
 
+				if (!io.initiated) {
+					/* Get the delay due to codec processing. */
+					t_pcm->processing_delay_dms = asrsync_get_dms_since_last_sync(&io.asrs);
+					io.initiated = true;
+				}
+
 				data += len;
 				data_len -= len;
 
 			}
 
-			/* keep data transfer at a constant bit rate */
+			/* Keep data transfer at a constant bit rate. */
 			asrsync_sync(&io.asrs, msbc.frames * MSBC_CODESAMPLES);
-			/* update busy delay (encoding overhead) */
-			t_pcm->processing_delay_dms = asrsync_get_busy_usec(&io.asrs) / 100;
 
 			/* Move unprocessed data to the front of our linear
 			 * buffer and clear the mSBC frame counter. */

--- a/src/shared/a2dp-codecs.c
+++ b/src/shared/a2dp-codecs.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - a2dp-codecs.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *

--- a/src/shared/rt.h
+++ b/src/shared/rt.h
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - rt.h
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -16,6 +16,7 @@
 # include <config.h>
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
 
@@ -41,7 +42,7 @@
 #endif
 
 /**
- * Structure used for time synchronization.
+ * Structure used for rate synchronization.
  *
  * With the size of the frame counter being 32 bits, it is possible to track
  * up to ~24 hours, with the sample rate of 48 kHz. If it is insufficient,
@@ -58,34 +59,19 @@ struct asrsync {
 	/* transferred frames since ts0 */
 	uint32_t frames;
 
-	/* time spent outside of the sync function */
-	struct timespec ts_busy;
-	/* If the asrsync_sync() returns a positive value, then this variable
-	 * contains an amount of time used for synchronization. Otherwise, it
-	 * contains an overdue time - synchronization was not possible due to
-	 * too much time spent outside of the sync function. */
+	/* Indicate whether the synchronization was required. */
+	bool synced;
+	/* If synchronization was required this variable contains an amount of
+	 * time used for the synchronization. Otherwise, it contains an overdue
+	 * time - synchronization was not possible due to too much time spent
+	 * outside of the sync function. */
 	struct timespec ts_idle;
 
 };
 
-/**
- * Start (initialize) time synchronization.
- *
- * @param asrs Pointer to the time synchronization structure.
- * @param sr Synchronization sample rate. */
-#define asrsync_init(asrs, sr) do { \
-		(asrs)->rate = sr; \
-		gettimestamp(&(asrs)->ts0); \
-		(asrs)->ts = (asrs)->ts0; \
-		(asrs)->frames = 0; \
-	} while (0)
-
-int asrsync_sync(struct asrsync *asrs, unsigned int frames);
-
-/**
- * Get the number of microseconds spent outside of the sync function. */
-#define asrsync_get_busy_usec(asrs) \
-	((asrs)->ts_busy.tv_nsec / 1000)
+void asrsync_init(struct asrsync *asrs, unsigned int rate);
+void asrsync_sync(struct asrsync *asrs, unsigned int frames);
+unsigned int asrsync_get_dms_since_last_sync(const struct asrsync *asrs);
 
 /**
  * Get system monotonic time-stamp.

--- a/test/test-a2dp.c
+++ b/test/test-a2dp.c
@@ -51,6 +51,8 @@ int ba_transport_pcm_state_set(struct ba_transport_pcm *pcm,
 enum ba_transport_pcm_signal ba_transport_pcm_signal_recv(struct ba_transport_pcm *pcm) {
 	(void)pcm; return -1; }
 void ba_transport_pcm_thread_cleanup(struct ba_transport_pcm *pcm) { (void)pcm; }
+int ba_transport_pcm_delay_sync(struct ba_transport_pcm *pcm, unsigned int update_mask) {
+	(void)pcm; (void)update_mask; return -1; }
 
 CK_START_TEST(test_a2dp_codecs_codec_id_from_string) {
 	ck_assert_uint_eq(a2dp_codecs_codec_id_from_string("SBC"), A2DP_CODEC_SBC);


### PR DESCRIPTION
I've raised this as a draft PR for discussion because:

1. I'm not sure if there is a reason why D-Bus signalling was omitted originally.
2. I'm not sure of the GIO dbus thread handling. This solution emits dbus signals from the transport I/O thread, but without any locking. Is that safe?
3. My choice of a 10ms difference threshold to limit the rate that signals can be emitted is entirely arbitrary with no specific evidence to justify it.