### PR TITLE
bluealsa-aplay delay reporting improvements

### DIFF
--- a/.github/spellcheck-wordlist.txt
+++ b/.github/spellcheck-wordlist.txt
@@ -68,6 +68,7 @@ ATRAC
 BlueALSA
 BlueZ
 Fraunhofer
+iPhone
 IWYU
 LDAC
 LHDC

--- a/doc/bluealsa-aplay.1.rst
+++ b/doc/bluealsa-aplay.1.rst
@@ -89,7 +89,7 @@ OPTIONS
 
 --pcm-buffer-time=INT
     Set the playback PCM buffer duration time to *INT* microseconds.
-    The default is 500000. It is recommended to choose a buffer time that is
+    The default is 200000. It is recommended to choose a buffer time that is
     an exact multiple of the period time to avoid potential issues with some
     ALSA plugins (see --pcm-period-time option below).
     ALSA may choose the nearest available alternative if the requested value is
@@ -101,7 +101,7 @@ OPTIONS
 
 --pcm-period-time=INT
     Set the playback PCM period duration time to *INT* microseconds.
-    The default is 100000.
+    The default is 50000.
     ALSA may choose the nearest available alternative if the requested value is
     not supported.
 
@@ -232,12 +232,12 @@ Instead it will choose its own values, which can lead to rounding errors in the
 period size calculation when used with the ALSA `rate` plugin. To avoid this,
 it is recommended to explicitly define the hardware period size and buffer size
 for dmix in your ALSA configuration. For example, suppose we want a period time
-of 100000 µs and a buffer holding 5 periods with an Intel 'PCH' card:
+of 50000 µs and a buffer holding 4 periods with an Intel 'PCH' card:
 
 ::
 
-    defaults.dmix.PCH.period_time 100000
-    defaults.dmix.PCH.periods 5
+    defaults.dmix.PCH.period_time 50000
+    defaults.dmix.PCH.periods 4
 
 Alternatively we can define a PCM with the required setting:
 
@@ -250,8 +250,8 @@ Alternatively we can define a PCM with the required setting:
             ipc_key 12345
             slave {
                 pcm "hw:0,0"
-                period_time 100000
-                periods 5
+                period_time 50000
+                periods 4
             }
         }
     }

--- a/utils/aplay/alsa-pcm.c
+++ b/utils/aplay/alsa-pcm.c
@@ -89,14 +89,16 @@ static int alsa_pcm_set_sw_params(snd_pcm_t *pcm, snd_pcm_uframes_t buffer_size,
 		goto fail;
 	}
 
-	/* start the transfer when the buffer is full (or almost full) */
-	snd_pcm_uframes_t threshold = (buffer_size / period_size) * period_size;
+	/* Start the transfer when the buffer is half full - this allows
+	 * spare capacity to accommodate bursts and short breaks in the
+	 * Bluetooth stream. */
+	snd_pcm_uframes_t threshold = buffer_size / 2;
 	if ((err = snd_pcm_sw_params_set_start_threshold(pcm, params, threshold)) != 0) {
 		snprintf(buf, sizeof(buf), "Set start threshold: %s: %lu", snd_strerror(err), threshold);
 		goto fail;
 	}
 
-	/* allow the transfer when at least period_size samples can be processed */
+	/* Allow the transfer when at least period_size samples can be processed. */
 	if ((err = snd_pcm_sw_params_set_avail_min(pcm, params, period_size)) != 0) {
 		snprintf(buf, sizeof(buf), "Set avail min: %s: %lu", snd_strerror(err), period_size);
 		goto fail;

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -86,8 +86,11 @@ static bool ba_profile_a2dp = true;
 static bool ba_addr_any = false;
 static bdaddr_t *ba_addrs = NULL;
 static size_t ba_addrs_count = 0;
-static unsigned int pcm_buffer_time = 500000;
-static unsigned int pcm_period_time = 100000;
+/* Many devices cannot synchronize A/V with very high audio latency. To keep
+ * the overall latency below 400ms we choose ALSA parameters such that the
+ * ALSA latency is below 200ms. */
+static unsigned int pcm_buffer_time = 200000;
+static unsigned int pcm_period_time = 50000;
 
 /* local PCM muted state for software mute */
 static bool pcm_muted = false;


### PR DESCRIPTION
This PR attempts to resolve two issues I've found with the new sink delay
reporting.

The first is that although A/V sync is mostly good with BlueALSA devices as source,
my iphone is unable to sync. I found that a typical commercial sink has a delay 
between 100ms and 200ms with both SBC and AAC codecs, whereas my BlueALSA sink
has a delay of over 400ms. By adjusting the bluealsa-aplay ALSA parameters to
reduce the delay, I can achieve very good A/V sync with both the iphone and
BlueALSA sources.

The second is that although A/V sync is generally very good, it can on occasion 
be understated by over 100ms (as measured by setting the ClientDelay property on
a BlueALSA source to correct the sync). I believe this is caused by the 
relative payload sizes of the L2CAP frames, codec frames, and ALSA start 
threshold, combined with the precise timing of the arrival of the initial L2CAP
frames. In some runs, sufficient PCM frames accumulate in the pcm pipe and/or 
bluealsa-aplay read buffer so that they cannot all be transferred to the ALSA 
buffer in a single iteration. So I have extended the delay calculation to 
account for these buffers, and so far with this change I have had always had
good A/V sync with all source devices .

This needs testing with a variety of sources and sink devices to check that the 
reduced default ALSA start threshold and buffer size do not lead underruns; I 
have not found any data to help select the "best" compromise values, so the
values chosen here are somewhat arbitrary.