### PR TITLE
Aplay resampler

### DIFF
--- a/.github/actions/apt-install-deps/action.yaml
+++ b/.github/actions/apt-install-deps/action.yaml
@@ -28,6 +28,7 @@ runs:
           libopenaptx-dev
           libopus-dev
           libreadline-dev
+          libsamplerate0-dev
           libsbc-dev
           libspandsp-dev
           python3-docutils

--- a/.github/spellcheck-wordlist.txt
+++ b/.github/spellcheck-wordlist.txt
@@ -13,6 +13,7 @@ CRC
 CTL
 CTLs
 CVSD
+DAC
 DRC
 ELD
 eSCO
@@ -215,6 +216,7 @@ HUP
 ioplug
 IPHONEACCEV
 jas
+jitter
 keyp
 larc
 LEAdvertisement
@@ -256,6 +258,7 @@ SIGIO
 SIGPIPE
 SIGSEGV
 SIGTERM
+SINC
 SL
 SNR
 spandsp

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,9 +17,9 @@ jobs:
         features:
         - --enable-debug
         - --enable-debug --enable-aac --enable-msbc --enable-lc3-swb
-        - --enable-debug --enable-mp3lame --enable-mpg123
+        - --enable-debug --enable-mp3lame --enable-mpg123 --enable-upower
         - --enable-faststream --enable-midi --enable-mp3lame
-        - --enable-ofono --enable-opus --enable-upower
+        - --enable-aplay --with-libsamplerate --enable-ofono --enable-opus
         - --disable-aplay --enable-rfcomm --enable-manpages
         - --disable-ctl --enable-aptx --enable-aptx-hd --with-libopenaptx
       fail-fast: false
@@ -126,6 +126,7 @@ jobs:
           --enable-opus \
           --enable-upower \
           --enable-aplay \
+          --with-libsamplerate \
           --enable-ctl \
           --enable-test
     - name: Build

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -59,6 +59,7 @@ jobs:
           --enable-opus \
           --enable-upower \
           --enable-aplay \
+          --with-libsamplerate \
           --enable-ctl \
           --enable-rfcomm \
           --enable-a2dpconf \
@@ -108,6 +109,7 @@ jobs:
           --enable-opus \
           --enable-upower \
           --enable-aplay \
+          --with-libsamplerate \
           --enable-ctl \
           --enable-rfcomm \
           --enable-a2dpconf \

--- a/.github/workflows/codecov-report.yaml
+++ b/.github/workflows/codecov-report.yaml
@@ -39,6 +39,7 @@ jobs:
           --enable-opus \
           --enable-upower \
           --enable-aplay \
+          --with-libsamplerate \
           --enable-ctl \
           --enable-test \
           --with-coverage

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ unreleased
 - optional support for A2DP Sink and Source with LHDC v3 codec
 - channel map and volume control for surround sound (5.1, 7.1) audio
 - native A2DP volume control by default (dropped --a2dp-volume option)
+- optional support for adaptive audio resampling in bluealsa-aplay
 - fix configuration for Android 13 A2DP Opus codec
 
 bluez-alsa v4.3.1 (2024-08-30)

--- a/configure.ac
+++ b/configure.ac
@@ -319,6 +319,14 @@ AC_ARG_ENABLE([aplay],
 	[AS_HELP_STRING([--disable-aplay], [disable building of bluealsa-aplay tool])])
 AM_CONDITIONAL([ENABLE_APLAY], [test "x$enable_aplay" != "xno"])
 
+AC_ARG_WITH([libsamplerate],
+	[AS_HELP_STRING([--with-libsamplerate], [use libsamplerate in bluealsa-aplay])])
+AM_CONDITIONAL([WITH_LIBSAMPLERATE], [test "x$with_libsamplerate" = "xyes"])
+AM_COND_IF([WITH_LIBSAMPLERATE], [
+	PKG_CHECK_MODULES([SAMPLERATE], [samplerate >= 0.2.0])
+	AC_DEFINE([WITH_LIBSAMPLERATE], [1], [Define to 1 if libsamplerate shall be used.])
+])
+
 AC_ARG_ENABLE([rfcomm],
 	[AS_HELP_STRING([--enable-rfcomm], [enable building of bluealsa-rfcomm tool])])
 AM_CONDITIONAL([ENABLE_RFCOMM], [test "x$enable_rfcomm" = "xyes"])

--- a/misc/bash-completion/bluealsad
+++ b/misc/bash-completion/bluealsad
@@ -265,7 +265,7 @@ _bluealsa_aplay() {
 			__ltrim_colon_completions "$cur"
 			return
 			;;
-		--loglevel|--volume)
+		--loglevel|--resampler|--volume)
 			readarray -t list < <(_bluealsa_enum_values "$1" "$prev")
 			readarray -t COMPREPLY < <(compgen -W "${list[*]}" -- "$cur")
 			return

--- a/src/shared/rt.h
+++ b/src/shared/rt.h
@@ -93,6 +93,12 @@ unsigned int asrsync_get_dms_since_last_sync(const struct asrsync *asrs);
  * @return Time in milliseconds. */
 #define timespec2ms(ts) ((ts)->tv_sec * 1000 + (ts)->tv_nsec / 1000000)
 
+/**
+ * Check whether the time defined by the timespec structure is zero. */
+static inline bool is_timespec_zero(const struct timespec *ts) {
+	return ts->tv_sec == 0 && ts->tv_nsec == 0;
+}
+
 int difftimespec(
 		const struct timespec *ts1,
 		const struct timespec *ts2,

--- a/utils/aplay/Makefile.am
+++ b/utils/aplay/Makefile.am
@@ -19,17 +19,24 @@ bluealsa_aplay_SOURCES = \
 	delay-report.c \
 	aplay.c
 
+if WITH_LIBSAMPLERATE
+bluealsa_aplay_SOURCES += \
+	resampler.c
+endif
+
 bluealsa_aplay_CFLAGS = \
 	-I$(top_srcdir)/src \
 	@ALSA_CFLAGS@ \
 	@BLUEZ_CFLAGS@ \
 	@DBUS1_CFLAGS@ \
-	@LIBUNWIND_CFLAGS@
+	@LIBUNWIND_CFLAGS@ \
+	@SAMPLERATE_CFLAGS@
 
 bluealsa_aplay_LDADD = \
 	@ALSA_LIBS@ \
 	@BLUEZ_LIBS@ \
 	@DBUS1_LIBS@ \
-	@LIBUNWIND_LIBS@
+	@LIBUNWIND_LIBS@ \
+	@SAMPLERATE_LIBS@
 
 endif

--- a/utils/aplay/alsa-pcm.h
+++ b/utils/aplay/alsa-pcm.h
@@ -49,11 +49,11 @@ struct alsa_pcm {
 
 	/* The internal delay of the ALSA device immediately
 	 * after the last write. */
-	size_t delay;
+	snd_pcm_uframes_t delay;
 
 	/* The number of frames in the ALSA ring buffer immediately
 	 * after the last write. */
-	size_t hw_avail;
+	snd_pcm_uframes_t hw_avail;
 
 };
 
@@ -63,7 +63,8 @@ void alsa_pcm_init(
 int alsa_pcm_open(
 		struct alsa_pcm *pcm,
 		const char *name,
-		snd_pcm_format_t format,
+		snd_pcm_format_t format_1,
+		snd_pcm_format_t format_2,
 		unsigned int channels,
 		unsigned int rate,
 		unsigned int buffer_time,
@@ -77,6 +78,11 @@ void alsa_pcm_close(
 inline static bool alsa_pcm_is_open(
 		const struct alsa_pcm *pcm) {
 	return pcm->pcm != NULL;
+}
+
+inline static bool alsa_pcm_is_running(
+		const struct alsa_pcm *pcm) {
+	return snd_pcm_state(pcm->pcm) == SND_PCM_STATE_RUNNING;
 }
 
 inline static ssize_t alsa_pcm_frames_to_bytes(

--- a/utils/aplay/delay-report.c
+++ b/utils/aplay/delay-report.c
@@ -30,36 +30,24 @@ void delay_report_init(
 		struct delay_report *dr,
 		struct ba_dbus_ctx *dbus_ctx,
 		struct ba_pcm *ba_pcm) {
-
 	memset(dr, 0, sizeof(*dr));
 	dr->dbus_ctx = dbus_ctx;
 	dr->ba_pcm = ba_pcm;
-
 }
 
 void delay_report_reset(
 		struct delay_report *dr) {
 	memset(dr->values, 0, sizeof(dr->values));
+	dr->values_i = 0;
 }
 
 bool delay_report_update(
 		struct delay_report *dr,
-		struct alsa_pcm *pcm,
-		int ba_pcm_fd,
-		ffb_t *buffer,
+		snd_pcm_uframes_t delay,
 		DBusError *err) {
 
-	unsigned int ba_pcm_buffered = 0;
-	/* Get the delay due to BlueALSA PCM FIFO buffering. */
-	ioctl(ba_pcm_fd, FIONREAD, &ba_pcm_buffered);
-	snd_pcm_sframes_t ba_pcm_frames = ba_pcm_buffered / pcm->frame_size;
-
-	/* Get the delay due to internal buffering. */
-	snd_pcm_sframes_t buffer_frames = ffb_blen_out(buffer) / pcm->frame_size;
-
 	const size_t num_values = ARRAYSIZE(dr->values);
-	/* Store the delay calculated from all components. */
-	dr->values[dr->values_i % num_values] = pcm->delay + ba_pcm_frames + buffer_frames;
+	dr->values[dr->values_i % num_values] = delay;
 	dr->values_i++;
 
 	struct timespec ts_now;
@@ -69,17 +57,21 @@ bool delay_report_update(
 	gettimestamp(&ts_now);
 	timespecadd(&dr->update_ts, &ts_delay, &ts_delay);
 
-	snd_pcm_sframes_t delay_frames_avg = 0;
+	snd_pcm_uframes_t delay_frames_avg = 0;
 	for (size_t i = 0; i < num_values; i++)
 		delay_frames_avg += dr->values[i];
-	delay_frames_avg /= num_values;
+	if (dr->values_i < num_values)
+		delay_frames_avg /= dr->values_i;
+	else
+		delay_frames_avg /= num_values;
+	dr->avg_value = delay_frames_avg;
 
-	const int delay = delay_frames_avg * 10000 / dr->ba_pcm->rate;
+	const int client_delay = delay_frames_avg * 10000 / dr->ba_pcm->rate;
 	if (difftimespec(&ts_now, &ts_delay, &ts_delay) >= 0 ||
-			abs(delay - dr->ba_pcm->client_delay) < 100 /* 10ms */)
+			abs(client_delay - dr->ba_pcm->client_delay) < 100 /* 10ms */)
 		return true;
 
 	dr->update_ts = ts_now;
-	dr->ba_pcm->client_delay = delay;
+	dr->ba_pcm->client_delay = client_delay;
 	return ba_dbus_pcm_update(dr->dbus_ctx, dr->ba_pcm, BLUEALSA_PCM_CLIENT_DELAY, err);
 }

--- a/utils/aplay/delay-report.h
+++ b/utils/aplay/delay-report.h
@@ -12,6 +12,10 @@
 #ifndef BLUEALSA_APLAY_DELAYREPORT_H_
 #define BLUEALSA_APLAY_DELAYREPORT_H_
 
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
 #include <stdbool.h>
 #include <time.h>
 
@@ -31,7 +35,8 @@ struct delay_report {
 	struct timespec update_ts;
 
 	/* Window buffer for calculating delay moving average. */
-	snd_pcm_sframes_t values[64];
+	snd_pcm_uframes_t values[64];
+	snd_pcm_uframes_t avg_value;
 	size_t values_i;
 
 };
@@ -46,9 +51,7 @@ void delay_report_reset(
 
 bool delay_report_update(
 		struct delay_report *dr,
-		struct alsa_pcm *pcm,
-		int ba_pcm_fd,
-		ffb_t *buffer,
+		snd_pcm_uframes_t delay,
 		DBusError *err);
 
 #endif

--- a/utils/aplay/resampler.c
+++ b/utils/aplay/resampler.c
@@ -1,0 +1,467 @@
+/*
+ * BlueALSA - resampler.c
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
+ * Copyright (c) 2025 borine
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#include "resampler.h"
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <endian.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/param.h>
+#include <sys/time.h>
+
+#include <alsa/asoundlib.h>
+#include <samplerate.h>
+
+#include "shared/log.h"
+#include "shared/ffb.h"
+#include "shared/rt.h"
+
+/* How many milliseconds to allow the delay to change before adjusting the
+ * resampling rate. This value must allow the delay to vary due to timer
+ * jitter without triggering a rate change. */
+# define RESAMPLER_TOLERANCE_MS 3
+
+/* How many milliseconds to wait for the delay value to stabilize after a
+ * reset. */
+#define RESAMPLER_STABILIZE_MS 5000
+
+/* Step size of rate adjustment. */
+#define RESAMPLER_STEP_SIZE 0.000004
+
+/* Limit how many increment steps can be made when adjusting rate ratio. */
+#define RESAMPLER_MAX_STEPS 100
+
+/* Ignore rapid changes in delay since such changes can only result from
+ * stream discontinuities, not timer drift. */
+#define RESAMPLER_MAX_CHANGE_MS 10
+
+/* Minimum time in milliseconds between rate ratio adjustments. */
+#define RESAMPLER_PERIOD_MS 100
+
+/* Number of samples to process in one go in case where the format
+ * conversion is required. */
+#define RESAMPLER_BUFFER_SIZE 4096
+
+static const struct timespec ts_stabilize = {
+	.tv_sec = RESAMPLER_STABILIZE_MS / 1000,
+	.tv_nsec = (RESAMPLER_STABILIZE_MS % 1000) * 1000000,
+};
+
+/**
+ * Check whether audio format is supported as input by the resampler. */
+bool resampler_is_input_format_supported(snd_pcm_format_t format) {
+	return format == SND_PCM_FORMAT_S16_LE ||
+		format == SND_PCM_FORMAT_S32_LE ||
+		format == SND_PCM_FORMAT_S24_LE;
+}
+
+/**
+ * Check whether audio format is supported as output by the resampler. */
+bool resampler_is_output_format_supported(snd_pcm_format_t format) {
+	return format == SND_PCM_FORMAT_S16 ||
+		format == SND_PCM_FORMAT_S32 ||
+		format == SND_PCM_FORMAT_FLOAT;
+}
+
+/**
+ * Initialize the resampler structure.
+ *
+ * @param resampler The resampler structure to initialize.
+ * @param type The type of the converter to use.
+ * @param channels The number of channels in the stream.
+ * @param in_format The sample format of the incoming stream.
+ * @param in_rate The nominal sample rate of the incoming stream.
+ * @param out_format The required output sample format.
+ * @param out_rate The nominal sample rate of the output stream.
+ * @param min_target The minimum target delay.
+ * @param max_target The maximum target delay.
+ * @return On success this function returns 0. Otherwise -1 is returned. */
+int resampler_init(
+		struct resampler *resampler,
+		enum resampler_converter_type type,
+		unsigned int channels,
+		snd_pcm_format_t in_format,
+		unsigned int in_rate,
+		snd_pcm_format_t out_format,
+		unsigned int out_rate,
+		snd_pcm_uframes_t min_target,
+		snd_pcm_uframes_t max_target) {
+
+	debug("Initializing resampler: min-delay=%#.1f max-delay=%#.1f",
+			1000.0 * min_target / in_rate, 1000.0 * max_target / in_rate);
+
+	/* Check whether formats can be resampled. */
+	if (!resampler_is_input_format_supported(in_format) ||
+			!resampler_is_output_format_supported(out_format)) {
+		return errno = EINVAL, -1;
+	}
+
+	int err;
+	if ((resampler->src_state = src_new(type, channels, &err)) == NULL) {
+		debug("Couldn't create converter: %s", src_strerror(err));
+		return errno = EINVAL, -1;
+	}
+
+	resampler->in_buffer = NULL;
+	if (in_format != SND_PCM_FORMAT_FLOAT) {
+		if ((resampler->in_buffer = malloc(RESAMPLER_BUFFER_SIZE * sizeof(float))) == NULL)
+			goto fail;
+	}
+
+	resampler->out_buffer = NULL;
+	if (out_format != SND_PCM_FORMAT_FLOAT) {
+		if ((resampler->out_buffer = malloc(RESAMPLER_BUFFER_SIZE * sizeof(float))) == NULL)
+			goto fail;
+	}
+
+	resampler->channels = channels;
+	resampler->in_format = in_format;
+	resampler->out_format = out_format;
+	resampler->min_target = min_target;
+	resampler->max_target = max_target;
+	resampler->max_delay_diff = RESAMPLER_MAX_CHANGE_MS * in_rate / 1000;
+	resampler->rate_ratio_step_count = 0;
+	resampler->delay_tolerance = RESAMPLER_TOLERANCE_MS * in_rate / 1000;
+	resampler->nominal_rate_ratio = (double)out_rate / (double)in_rate;
+	resampler->steady_rate_ratio_step_count = 0;
+	resampler->src_data.src_ratio = resampler->nominal_rate_ratio;
+	resampler->input_frames = 0;
+	resampler->last_input_frames = 0;
+	resampler->period = RESAMPLER_PERIOD_MS * in_rate / 1000;
+	resampler->in_rate = in_rate;
+
+	return 0;
+
+fail:
+	resampler_free(resampler);
+	return -1;
+}
+
+/**
+ * Free resources allocated for the resampler. */
+void resampler_free(struct resampler *resampler) {
+	if (resampler->src_state != NULL) {
+		src_delete(resampler->src_state);
+		resampler->src_state = NULL;
+	}
+	free(resampler->in_buffer);
+	resampler->in_buffer = NULL;
+	free(resampler->out_buffer);
+	resampler->out_buffer = NULL;
+}
+
+/**
+ * Resample as many frames as possible from the buffer in to the buffer out. */
+int resampler_process(struct resampler *resampler, ffb_t *in, ffb_t *out) {
+
+	const unsigned int channels = resampler->channels;
+	const size_t in_samples_total = ffb_len_out(in);
+	SRC_DATA *src_data = &resampler->src_data;
+	size_t samples_used = 0;
+
+	/* If the input sample format is FLOAT we can process them directly
+	 * without any intermediate conversion. Otherwise, we need to use our
+	 * internal buffer to convert the samples to FLOAT before processing. */
+	if (resampler->in_format != SND_PCM_FORMAT_FLOAT)
+		src_data->data_in = resampler->in_buffer;
+	else
+		src_data->data_in = in->data;
+
+	/* The same case applies to the output sample format. */
+	if (resampler->out_format != SND_PCM_FORMAT_FLOAT)
+		src_data->data_out = resampler->out_buffer;
+	else
+		src_data->data_out = out->tail;
+
+	while (true) {
+
+		size_t in_samples = in_samples_total - samples_used;
+		size_t out_samples = ffb_len_in(out);
+
+		/* Convert input samples to FLOAT format if necessary. */
+		if (resampler->in_format != SND_PCM_FORMAT_FLOAT) {
+
+			in_samples = MIN(in_samples, RESAMPLER_BUFFER_SIZE);
+
+			if (resampler->in_format == SND_PCM_FORMAT_S16_LE) {
+				const int16_t *in_data = in->data;
+				src_short_to_float_array(in_data + samples_used, resampler->in_buffer, in_samples);
+			}
+			else if (resampler->in_format == SND_PCM_FORMAT_S32_LE) {
+				const int32_t *in_data = in->data;
+				src_int_to_float_array(in_data + samples_used, resampler->in_buffer, in_samples);
+			}
+
+		}
+
+		if (resampler->out_format != SND_PCM_FORMAT_FLOAT)
+			out_samples = MIN(out_samples, RESAMPLER_BUFFER_SIZE);
+
+		src_data->input_frames = in_samples / channels;
+		src_data->output_frames = out_samples / channels;
+
+		int err;
+		if ((err = src_process(resampler->src_state, src_data)) != 0) {
+			error("Resampling failed: %s", src_strerror(err));
+			return err;
+		}
+
+		if (src_data->output_frames_gen == 0)
+			break;
+
+		const size_t samples_gen = src_data->output_frames_gen * channels;
+		samples_used += src_data->input_frames_used * channels;
+
+		/* Convert output samples to integer format if necessary. */
+		if (resampler->out_format == SND_PCM_FORMAT_S16)
+			src_float_to_short_array(resampler->out_buffer, out->tail, samples_gen);
+		else if (resampler->out_format == SND_PCM_FORMAT_S32)
+			src_float_to_int_array(resampler->out_buffer, out->tail, samples_gen);
+
+		ffb_seek(out, samples_gen);
+
+	}
+
+	ffb_shift(in, samples_used);
+	return 0;
+}
+
+/**
+ * Reset the resampling ratio to its nominal rate.
+ *
+ * This function should be called after any discontinuity in the stream. */
+void resampler_reset(struct resampler *resampler) {
+	resampler->src_data.src_ratio = resampler->nominal_rate_ratio;
+	resampler->rate_ratio_step_count = 0;
+	resampler->steady_rate_ratio_step_count = 0;
+	/* Disable adaptive resampling until the delay has had time to settle. */
+	resampler->target_delay = 0;
+	gettimestamp(&resampler->reset_ts);
+}
+
+double resampler_current_rate_ratio(const struct resampler *resampler) {
+	return resampler->src_data.src_ratio;
+}
+
+/**
+ * Change the rate ratio applied by the resampler to adjust for the given new
+ * delay value, always trying to move the delay back towards the target value.
+ *
+ * @return Returns true if the rate ratio was changed. */
+bool resampler_update_rate_ratio(
+		struct resampler *resampler,
+		snd_pcm_uframes_t frames_read,
+		snd_pcm_uframes_t delay) {
+
+	bool ret = false;
+
+	/* Update the rate ratio only if at least one period
+	 * has passed since the last update. */
+	if (frames_read > 0) {
+		resampler->input_frames += frames_read;
+		/* Prevent the possibility of integer overflow. */
+		resampler->input_frames %= INTMAX_MAX;
+		if (resampler->input_frames - resampler->last_input_frames < resampler->period)
+			return false;
+		resampler->last_input_frames = resampler->input_frames;
+	}
+
+	if (resampler->target_delay == 0 && !is_timespec_zero(&resampler->reset_ts)) {
+		/* Do not restart adaptive resampling until the delay has had time to
+		 * settle to a new value. */
+		struct timespec ts_wait;
+		struct timespec ts_now;
+		gettimestamp(&ts_now);
+		timespecadd(&resampler->reset_ts, &ts_stabilize, &ts_wait);
+		if (difftimespec(&ts_now, &ts_wait, &ts_wait) < 0) {
+			/* Do not allow the target to be outside the configured range. If
+			 * the actual delay is outside that range then try to move it back
+			 * as quickly as possible. */
+			if (delay > resampler->max_target) {
+				resampler->target_delay = resampler->max_target;
+				resampler->src_data.src_ratio =
+					resampler->nominal_rate_ratio - RESAMPLER_STEP_SIZE * RESAMPLER_MAX_STEPS;
+				resampler->rate_ratio_step_count = -RESAMPLER_MAX_STEPS;
+			}
+			else if (delay < resampler->min_target) {
+				resampler->target_delay = resampler->min_target;
+				resampler->src_data.src_ratio =
+					resampler->nominal_rate_ratio + RESAMPLER_STEP_SIZE * RESAMPLER_MAX_STEPS;
+				resampler->rate_ratio_step_count = RESAMPLER_MAX_STEPS;
+			}
+			else {
+				/* Once the delay has returned within the permitted target
+				 * range, zero the reset timestamp to indicate that normal
+				 * adaptive resampling has re-started. */
+				resampler->reset_ts.tv_sec = 0;
+				resampler->reset_ts.tv_nsec = 0;
+				resampler->target_delay = delay;
+			}
+			resampler->delay_diff = delay - resampler->target_delay;
+			debug("Adaptive resampling target delay: %#.1f ms",
+					1000.0 * resampler->target_delay / resampler->in_rate);
+			return true;
+		}
+		return false;
+	}
+
+	snd_pcm_sframes_t delay_diff = delay - resampler->target_delay;
+	snd_pcm_uframes_t delay_diff_abs = labs(delay_diff);
+
+	/* Reset the resampler whenever the delay exceeds the limit. */
+	if (delay_diff_abs > resampler->max_delay_diff) {
+		/* Reset the resampler if not already done. */
+		if (is_timespec_zero(&resampler->reset_ts)) {
+#if DEBUG
+			if (resampler->target_delay != 0)
+				/* Omit the log message if the target delay is not yet set. In such
+				 * case we are just initializing the resampler, not resetting it. */
+				debug("Resetting resampler: Delay difference limit exceeded: %zu > %zu",
+						delay_diff_abs, resampler->max_delay_diff);
+#endif
+			resampler_reset(resampler);
+			return true;
+		}
+	}
+
+	if (delay_diff_abs > resampler->delay_tolerance) {
+		/* When the delay is not already moving back towards tolerance,
+		 * step the size of the rate adjustment in the appropriate
+		 * direction. */
+		if (delay_diff > 0 && delay_diff > resampler->delay_diff) {
+			if (resampler->rate_ratio_step_count > -RESAMPLER_MAX_STEPS) {
+				resampler->src_data.src_ratio -= RESAMPLER_STEP_SIZE;
+				resampler->rate_ratio_step_count--;
+				ret = true;
+			}
+		}
+		else if (delay_diff < 0 && delay_diff < resampler->delay_diff) {
+			if (resampler->rate_ratio_step_count < RESAMPLER_MAX_STEPS) {
+				resampler->src_data.src_ratio += RESAMPLER_STEP_SIZE;
+				resampler->rate_ratio_step_count++;
+				ret = true;
+			}
+		}
+	}
+	else if (labs(resampler->delay_diff) > resampler->delay_tolerance) {
+		/* When the delay has returned to tolerance, step the size of the steady
+		 * rate ratio in the appropriate direction and set the rate ratio to
+		 * the revised steady rate ratio. */
+		if (resampler->delay_diff > 0) {
+			if (resampler->steady_rate_ratio_step_count > -RESAMPLER_MAX_STEPS) {
+				resampler->steady_rate_ratio_step_count--;
+				ret = true;
+			}
+		}
+		else {
+			if (resampler->steady_rate_ratio_step_count > RESAMPLER_MAX_STEPS) {
+				resampler->steady_rate_ratio_step_count++;
+				ret = true;
+			}
+		}
+		if (ret) {
+			resampler->rate_ratio_step_count = resampler->steady_rate_ratio_step_count;
+			resampler->src_data.src_ratio =
+				resampler->nominal_rate_ratio + RESAMPLER_STEP_SIZE * resampler->rate_ratio_step_count;
+		}
+	}
+
+	resampler->delay_diff = delay_diff;
+
+	return ret;
+}
+
+/**
+ * Convert a buffer of PCM samples to the equivalent native-endian format. The
+ * samples are modified in place. Also pad 24bit samples (packed into 32bits)
+ * to convert them to valid 32-bit samples.
+ *
+ * @param buffer The buffer of samples to convert.
+ * @param len The number of samples in the buffer.
+ * @param format The original format of the samples. */
+void resampler_convert_to_native_endian_format(
+		void *buffer, size_t len, snd_pcm_format_t format) {
+#if __BYTE_ORDER == __BIG_ENDIAN
+
+	switch (format) {
+	case SND_PCM_FORMAT_S16_LE: {
+		uint16_t *data = buffer;
+		for (size_t n = 0; n < len; n++)
+			le16toh(data[n]);
+	} break;
+	case SND_PCM_FORMAT_S24_LE: {
+		uint32_t *data = buffer;
+		for (size_t n = 0; n < len; n++) {
+			le32toh(data[n]);
+			/* convert to S32 */
+			data[n] <<= 8;
+		}
+	} break;
+	case SND_PCM_FORMAT_S32_LE: {
+		uint32_t *data = buffer;
+		for (size_t n = 0; n < len; n++)
+			le32toh(data[n]);
+	} break;
+	default:
+		return;
+	}
+
+#else
+
+	switch (format) {
+	case SND_PCM_FORMAT_S24_LE: {
+		uint32_t *data = buffer;
+		for (size_t n = 0; n < len; n++) {
+			/* convert to S32 */
+			data[n] <<= 8;
+		}
+	} break;
+	default:
+		return;
+	}
+
+#endif
+}
+
+/**
+ * Return the equivalent native-endian format for the given format.
+ * For unsupported formats the given source format value is returned. */
+snd_pcm_format_t resampler_native_endian_format(snd_pcm_format_t format) {
+#if __BYTE_ORDER == __BIG_ENDIAN
+	switch (format) {
+	case SND_PCM_FORMAT_S16_LE:
+		return SND_PCM_FORMAT_S16;
+	case SND_PCM_FORMAT_S24_LE:
+		/* 24-bit samples must be converted to 32-bit
+		 * before passing to the resampler. */
+		return SND_PCM_FORMAT_S32;
+	case SND_PCM_FORMAT_S32_LE:
+		return SND_PCM_FORMAT_S32;
+	default:
+		return format;
+	}
+#else
+	if (format == SND_PCM_FORMAT_S24_LE)
+		/* 24-bit samples must be converted to 32-bit
+		 * before passing to the resampler. */
+		return SND_PCM_FORMAT_S32;
+	return format;
+#endif
+}
+
+snd_pcm_format_t resampler_preferred_output_format(void) {
+	return SND_PCM_FORMAT_FLOAT;
+}

--- a/utils/aplay/resampler.h
+++ b/utils/aplay/resampler.h
@@ -1,0 +1,123 @@
+/*
+ * BlueALSA - resampler.h
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
+ * Copyright (c) 2025 borine
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#pragma once
+#ifndef BLUEALSA_APLAY_RESAMPLER_H_
+#define BLUEALSA_APLAY_RESAMPLER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+
+#include <alsa/asoundlib.h>
+#include <samplerate.h>
+
+#include "shared/ffb.h"
+
+struct resampler {
+
+	/* The state and configuration data. */
+	SRC_STATE *src_state;
+	SRC_DATA src_data;
+
+	/* Internal buffers for converting from
+	 * integer to float sample formats. */
+	float *in_buffer;
+	float *out_buffer;
+
+	/* The number of channels of the stream. */
+	unsigned int channels;
+
+	/* input sample format */
+	snd_pcm_format_t in_format;
+	/* output sample format */
+	snd_pcm_format_t out_format;
+
+	/* lower bound on the selected target delay */
+	snd_pcm_uframes_t min_target;
+	/* upper bound on the selected target delay */
+	snd_pcm_uframes_t max_target;
+	/* conversion ratio assuming zero timer drift */
+	double nominal_rate_ratio;
+	/* how many steps above or below nominal rate ratio for next processing iteration */
+	int rate_ratio_step_count;
+	/* current best estimate of step count to give steady delay value */
+	int steady_rate_ratio_step_count;
+	/* delay value that conversion tries to achieve */
+	snd_pcm_uframes_t target_delay;
+	/* variation in delay tolerated without changing number of steps */
+	snd_pcm_uframes_t delay_tolerance;
+	/* difference between delay and target delay at last processing iteration */
+	snd_pcm_sframes_t delay_diff;
+	/* upper bound on absolute delay difference before automatic reset */
+	snd_pcm_uframes_t max_delay_diff;
+	/* total number of input frames processed */
+	uintmax_t input_frames;
+	/* total number of input frames at time of last rate ratio update */
+	uintmax_t last_input_frames;
+	/* minimum number of input frames between rate ratio updates */
+	snd_pcm_uframes_t period;
+	/* timestamp of last resampler reset */
+	struct timespec reset_ts;
+	/* nominal sample rate of the incoming stream */
+	unsigned int in_rate;
+
+};
+
+enum resampler_converter_type {
+	RESAMPLER_CONV_NONE                   = -1,
+	RESAMPLER_CONV_SINC_BEST_QUALITY      = SRC_SINC_BEST_QUALITY,
+	RESAMPLER_CONV_SINC_MEDIUM_QUALITY    = SRC_SINC_MEDIUM_QUALITY,
+	RESAMPLER_CONV_SINC_FASTEST           = SRC_SINC_FASTEST,
+	RESAMPLER_CONV_ZERO_ORDER_HOLD        = SRC_ZERO_ORDER_HOLD,
+	RESAMPLER_CONV_LINEAR                 = SRC_LINEAR,
+};
+
+bool resampler_is_input_format_supported(snd_pcm_format_t format);
+bool resampler_is_output_format_supported(snd_pcm_format_t format);
+
+int resampler_init(
+		struct resampler *resampler,
+		enum resampler_converter_type type,
+		unsigned int channels,
+		snd_pcm_format_t in_format,
+		unsigned int in_rate,
+		snd_pcm_format_t out_format,
+		unsigned int out_rate,
+		snd_pcm_uframes_t min_target,
+		snd_pcm_uframes_t max_target);
+
+void resampler_free(
+		struct resampler *resampler);
+
+int resampler_process(
+		struct resampler *resampler,
+		ffb_t *in,
+		ffb_t *out);
+
+void resampler_reset(
+		struct resampler *resampler);
+
+double resampler_current_rate_ratio(
+		const struct resampler *resampler);
+
+bool resampler_update_rate_ratio(
+		struct resampler *resampler,
+		snd_pcm_uframes_t frames_read,
+		snd_pcm_uframes_t delay);
+
+void resampler_convert_to_native_endian_format(
+		void *buffer, size_t len, snd_pcm_format_t format);
+
+snd_pcm_format_t resampler_native_endian_format(snd_pcm_format_t format);
+snd_pcm_format_t resampler_preferred_output_format(void);
+
+#endif


### PR DESCRIPTION
This is my attempt to address the topics previously discussed in PR #459

The libsamplerate resampler causes high CPU usage. Its not so bad on x86_64, but really very high on armhf. I have not tried with arm64. Having said that, I have tested on an old pi zero W (32bit armv6) with the "SINC_FASTEST" converter and got very stable audio with accurate delay reporting watching a 4 hour video stream. `top` showed bluealsa-aplay consuming 28% of the (single core) CPU but the pi continued to run smoothly. So anyway this is left as an option and not included in the build by default. 