### PR TITLE
Aplay changes

### DIFF
--- a/doc/bluealsa-aplay.1.rst
+++ b/doc/bluealsa-aplay.1.rst
@@ -6,7 +6,7 @@ bluealsa-aplay
 a simple BlueALSA player
 ------------------------
 
-:Date: February 2025
+:Date: April 2025
 :Manual section: 1
 :Manual group: General Commands Manual
 :Version: $VERSION$
@@ -176,9 +176,13 @@ OPTIONS
     Set the name of the ALSA simple mixer control to use.
     The default is ``Master``.
 
-    To work with **bluealsa-aplay** this simple control must provide decibel
-    scaling information for the volume control. Most, but not all, modern sound
-    cards do provide this information.
+    If this simple control provides decibel scaling information then
+    **bluealsa-aplay** uses that information when converting the Bluetooth
+    volume level to or from a value for the control. When no decibel scaling
+    information is available then **bluealsa-aplay** assumes that the control
+    has a linear scale.
+    Most, but not all, modern sound cards do provide decibel scaling
+    information.
 
 --mixer-index=NUM
     Set the index of the ALSA simple mixer control.

--- a/doc/bluealsa-aplay.1.rst
+++ b/doc/bluealsa-aplay.1.rst
@@ -171,8 +171,12 @@ OPTIONS
     and volume level.
     In order to use this feature, BlueALSA PCM can not use software volume.
     The default is ``default``.
+    Note that **bluealsa-aplay** does not assume that the mixer device has the
+    same name, or is on the same card, as the PCM device. If this option is not
+    given then it will use ``default`` as the mixer device no matter which name
+    is given with the **--pcm=** option.
 
---mixer-name=NAME
+--mixer-control=NAME
     Set the name of the ALSA simple mixer control to use.
     The default is ``Master``.
 
@@ -260,14 +264,15 @@ adjustment will have been applied to the PCM stream within the **bluealsad**
 daemon; so **bluealsa-aplay** does not operate the mixer control in this case.
 
 When using ``--volume=none`` or ``--volume=software``, then the mixer options
-``--mixer-device``, ``--mixer-name`` and ``--mixer-index`` are ignored, and
+``--mixer-device``, ``--mixer-control`` and ``--mixer-index`` are ignored, and
 **bluealsa-aplay** will not operate any mixer controls, even if some other
 application changes the PCM volume mode to native while in use.
 
-When using ``--volume=auto`` or ``--volume=mixer`` the ALSA mixer control will
-be operated only when the PCM stream is active, (i.e., the remote device is
-sending audio). If a connected remote device requests a volume change when no
-active stream is playing, then **bluealsa-aplay** will ignore that request.
+When native volume control is enabled (using either ``--volume=auto`` or
+``--volume=mixer``) then the ALSA mixer control will be operated only when the
+PCM stream is active (i.e., the remote device is sending audio). If a
+connected remote device requests a volume change when no active stream is
+playing, then **bluealsa-aplay** will ignore that request.
 When the audio stream starts then **bluealsa-aplay** will change the Bluetooth
 volume to match the current setting of the ALSA mixer control.
 
@@ -409,7 +414,7 @@ above).
 ::
 
     bluealsa-aplay --pcm=default 94:B8:6D:AF:CD:EF F8:87:F1:B8:30:85 &
-    bluealsa-aplay --pcm=default:USB --mixer-device=hw:USB --mixer-name=Speaker C8:F7:33:66:F0:DE &
+    bluealsa-aplay --pcm=default:USB --mixer-device=hw:USB --mixer-control=Speaker C8:F7:33:66:F0:DE &
 
 Such setup will route ``94:B8:6D:AF:CD:EF`` and ``F8:87:F1:B8:30:85`` Bluetooth
 devices to the ``default`` ALSA playback PCM device and ``C8:F7:33:66:F0:DE``

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -1677,6 +1677,7 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 	if (stream == SND_PCM_STREAM_CAPTURE)
 		if ((pcm->null_fd = open("/dev/null", O_WRONLY | O_NONBLOCK)) == -1) {
 			SNDERR("Couldn't open /dev/null: %s", strerror(errno));
+			ret = -errno;
 			goto fail;
 		}
 

--- a/test/test-utils-aplay.c
+++ b/test/test-utils-aplay.c
@@ -77,7 +77,7 @@ CK_START_TEST(test_configuration) {
 				"--pcm-buffer-time=10000",
 				"--pcm-period-time=500",
 				"--mixer-device=TestMixer",
-				"--mixer-name=TestMixerName",
+				"--mixer-control=TestMixerName",
 				"--mixer-index=1",
 				"--profile-sco",
 				"12:34:56:78:90:AB",
@@ -242,7 +242,7 @@ CK_START_TEST(test_play_mixer_setup) {
 				"--pcm=bluealsa:PROFILE=sco",
 				"--volume=mixer",
 				"--mixer-device=bluealsa:DEV=23:45:67:89:AB:CD",
-				"--mixer-name=SCO",
+				"--mixer-control=SCO",
 				"-v",
 				NULL), -1);
 	spawn_terminate(&sp_ba_aplay, 500);

--- a/utils/aplay/alsa-mixer.c
+++ b/utils/aplay/alsa-mixer.c
@@ -45,7 +45,6 @@ int alsa_mixer_open(
 		char **msg) {
 
 	char buf[256];
-	long vmin_db;
 	int err;
 
 	snd_mixer_selem_id_t *id;
@@ -77,9 +76,23 @@ int alsa_mixer_open(
 
 	mixer->has_mute_switch = snd_mixer_selem_has_playback_switch(mixer->elem);
 
-	if ((err = snd_mixer_selem_get_playback_dB_range(mixer->elem,
-					&vmin_db, &mixer->volume_db_max_value)) != 0)
-		warn("Couldn't get ALSA mixer playback dB range: %s", snd_strerror(err));
+	/* To determine whether a control has a dB scale defined, we fetch the
+	 * dB scale limits and check that they are valid. */
+	mixer->has_db_scale = (snd_mixer_selem_get_playback_dB_range(mixer->elem,
+					&mixer->volume_min_value, &mixer->volume_max_value) == 0 &&
+					mixer->volume_min_value < mixer->volume_max_value);
+
+	/* For controls that lack a dB scale, we assume a simple linear scale
+	 * provided that we can obtain valid scale limits. */
+	if (!mixer->has_db_scale &&
+			(((err = snd_mixer_selem_get_playback_volume_range(mixer->elem,
+					&mixer->volume_min_value, &mixer->volume_max_value)) != 0) ||
+					mixer->volume_min_value >= mixer->volume_max_value)) {
+		snprintf(buf, sizeof(buf), "Couldn't get playback volume range: %s", snd_strerror(err));
+		if (err == 0)
+			err = EIO;
+		goto fail;
+	}
 
 	snd_mixer_elem_set_callback(mixer->elem, alsa_mixer_elem_callback);
 	snd_mixer_elem_set_callback_private(mixer->elem, mixer);
@@ -108,19 +121,27 @@ int alsa_mixer_get_volume(
 		bool *muted) {
 
 	snd_mixer_elem_t *elem = mixer->elem;
-	long long volume_db_sum = 0;
+	long long volume_sum = 0;
 	bool alsa_muted = true;
 
 	snd_mixer_selem_channel_id_t ch;
 	for (ch = 0; snd_mixer_selem_has_playback_channel(elem, ch) == 1; ch++) {
 
-		long ch_volume_db;
+		long ch_volume;
 		int ch_switch = 1;
 		int err;
 
-		if ((err = snd_mixer_selem_get_playback_dB(elem, ch, &ch_volume_db)) != 0) {
-			error("Couldn't get ALSA mixer playback dB level: %s", snd_strerror(err));
-			return -1;
+		if (mixer->has_db_scale) {
+			if ((err = snd_mixer_selem_get_playback_dB(elem, ch, &ch_volume)) != 0) {
+				error("Couldn't get ALSA mixer playback dB level: %s", snd_strerror(err));
+				return -1;
+			}
+		}
+		else {
+			if ((err = snd_mixer_selem_get_playback_volume(elem, ch, &ch_volume)) != 0) {
+				error("Couldn't get ALSA mixer playback volume level: %s", snd_strerror(err));
+				return -1;
+			}
 		}
 
 		/* Mute switch is an optional feature for a mixer element. */
@@ -130,22 +151,34 @@ int alsa_mixer_get_volume(
 			return -1;
 		}
 
-		volume_db_sum += ch_volume_db;
-		/* Normalize volume level so it will not exceed 0.00 dB. */
-		volume_db_sum -= mixer->volume_db_max_value;
+		volume_sum += ch_volume;
 
 		if (ch_switch == 1)
 			alsa_muted = false;
 
 	}
 
-	/* Safety check for undefined behavior from
-	 * out-of-bounds dB conversion. */
-	assert(volume_db_sum <= 0LL);
-
-	/* Convert dB to loudness using decibel formula and
-	 * round to the nearest integer. */
-	*volume = lround(pow(2, (0.01 * volume_db_sum / ch) / 10) * vmax);
+	if (mixer->has_db_scale) {
+		/* Normalize volume level so it will not exceed 0.00 dB. */
+		volume_sum -= ch * mixer->volume_max_value;
+		/* Safety check for undefined behavior from
+		 * out-of-bounds dB conversion. */
+		assert(volume_sum <= 0LL);
+		/* Convert dB to loudness using decibel formula and
+		 * round to the nearest integer. */
+		*volume = lround(pow(2, (0.01 * volume_sum / ch) / 10) * vmax);
+	}
+	else {
+		/* For raw linear scale use average value of channels. */
+		volume_sum /= ch;
+		/* Ensure returned volume is within valid range. */
+		if (volume_sum < mixer->volume_min_value)
+			volume_sum = mixer->volume_min_value;
+		if (volume_sum > mixer->volume_max_value)
+			volume_sum = mixer->volume_max_value;
+		const long range = mixer->volume_max_value - mixer->volume_min_value;
+		*volume = vmax * (volume_sum - mixer->volume_min_value) / range;
+	}
 
 	/* If mixer element supports playback switch,
 	 * return the actual mute state to the caller. */
@@ -161,15 +194,24 @@ int alsa_mixer_set_volume(
 		unsigned int volume,
 		bool muted) {
 
-	/* Convert loudness to dB using decibel formula. */
-	long db = 10 * log2(1.0 * volume / vmax) * 100;
-	/* Shift dB level so it will match hardware range. */
-	db += mixer->volume_db_max_value;
-
 	int err;
-	if ((err = snd_mixer_selem_set_playback_dB_all(mixer->elem, db, 0)) != 0) {
-		error("Couldn't set ALSA mixer playback dB level: %s", snd_strerror(err));
-		return -1;
+	if (mixer->has_db_scale) {
+		/* Convert loudness to dB using decibel formula. */
+		long db = 10 * log2(1.0 * volume / vmax) * 100;
+		/* Shift dB level so it will match hardware range. */
+		db += mixer->volume_max_value;
+		if ((err = snd_mixer_selem_set_playback_dB_all(mixer->elem, db, 0)) != 0) {
+			error("Couldn't set ALSA mixer playback dB level: %s", snd_strerror(err));
+			return -1;
+		}
+	}
+	else {
+		const long range = mixer->volume_max_value - mixer->volume_min_value;
+		long value = mixer->volume_min_value + (range * volume / vmax);
+		if ((err = snd_mixer_selem_set_playback_volume_all(mixer->elem, value)) != 0) {
+			error("Couldn't set ALSA mixer playback volume level: %s", snd_strerror(err));
+			return -1;
+		}
 	}
 
 	/* Mute switch is an optional feature for a mixer element. */

--- a/utils/aplay/alsa-mixer.h
+++ b/utils/aplay/alsa-mixer.h
@@ -26,8 +26,10 @@ struct alsa_mixer {
 	snd_mixer_t *mixer;
 	snd_mixer_elem_t *elem;
 
-	long volume_db_max_value;
+	bool has_db_scale;
 	bool has_mute_switch;
+	long volume_min_value;
+	long volume_max_value;
 
 	alsa_mixer_event_handler event_handler;
 	void *event_handler_userdata;

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -838,7 +838,8 @@ static void *io_worker_routine(struct io_worker *w) {
 						"  ALSA PCM period time: %u us (%zu bytes)\n"
 						"  ALSA PCM format: %s\n"
 						"  ALSA PCM sample rate: %u Hz\n"
-						"  ALSA PCM channels: %u",
+						"  ALSA PCM channels: %u\n"
+						"  ALSA mixer volume mapping: %s",
 						w->addr,
 						snd_pcm_format_name(pcm_format),
 						w->ba_pcm.rate,
@@ -847,7 +848,8 @@ static void *io_worker_routine(struct io_worker *w) {
 						w->alsa_pcm.period_time, alsa_pcm_frames_to_bytes(&w->alsa_pcm, w->alsa_pcm.period_frames),
 						snd_pcm_format_name(w->alsa_pcm.format),
 						w->alsa_pcm.rate,
-						w->alsa_pcm.channels);
+						w->alsa_pcm.channels,
+						w->alsa_mixer.mixer ? (w->alsa_mixer.has_db_scale ? "dB scale" : "linear") : "none");
 			}
 
 			if (verbose >= 3)

--- a/utils/aplay/aplay.c
+++ b/utils/aplay/aplay.c
@@ -1216,7 +1216,7 @@ int main(int argc, char *argv[]) {
 		{ "pcm-period-time", required_argument, NULL, 4 },
 		{ "volume", required_argument, NULL, '8' },
 		{ "mixer-device", required_argument, NULL, 'M' },
-		{ "mixer-name", required_argument, NULL, 6 },
+		{ "mixer-control", required_argument, NULL, 6 },
 		{ "mixer-index", required_argument, NULL, 7 },
 		{ "profile-a2dp", no_argument, NULL, 1 },
 		{ "profile-sco", no_argument, NULL, 2 },
@@ -1256,7 +1256,7 @@ int main(int argc, char *argv[]) {
 					"  --pcm-period-time=INT\t\tplayback PCM period time\n"
 					"  --volume=TYPE\t\t\tvolume control type [auto|mixer|none|software]\n"
 					"  -M, --mixer-device=NAME\tmixer device to use\n"
-					"  --mixer-name=NAME\t\tmixer element name\n"
+					"  --mixer-control=NAME\t\tmixer control name\n"
 					"  --mixer-index=NUM\t\tmixer element index\n"
 					"  --profile-a2dp\t\tuse A2DP profile (default)\n"
 					"  --profile-sco\t\t\tuse SCO profile\n"
@@ -1370,7 +1370,7 @@ int main(int argc, char *argv[]) {
 		case 'M' /* --mixer-device=NAME */ :
 			mixer_device = optarg;
 			break;
-		case 6 /* --mixer-name=NAME */ :
+		case 6 /* --mixer-control=NAME */ :
 			mixer_elem_name = optarg;
 			break;
 		case 7 /* --mixer-index=NUM */ :


### PR DESCRIPTION
Changes aimed at clarifying some points made in issue #757

I am not convinced that "guessing" the appropriate mixer or control element would really improve the general user experience. Instead these changes try to explain more clearly what happens when explicit options for mixer device or control name are not given on the command line.

Devices that do not give dB scale TLV data are supported by assuming a simple linear scale; this is the same approach as is used by alsamixer, so should give a familiar experience for users of such devices.