### PR TITLE
Multi client support

### DIFF
--- a/.github/iwyu.imp
+++ b/.github/iwyu.imp
@@ -53,4 +53,6 @@
 	{ include: [ '<spandsp/g722.h>', private, '<spandsp.h>', public ] },
 	{ include: [ '<spandsp/plc.h>', private, '<spandsp.h>', public ] },
 
+	{ include: [ '<bits/types/struct_itimerspec.h>', private, '<sys/timerfd.h>', public ] },
+
 ]

--- a/.github/spellcheck-wordlist.txt
+++ b/.github/spellcheck-wordlist.txt
@@ -177,6 +177,8 @@ BTRH
 BTT
 bttransport
 btusb
+# aspell considers PIPE_BUF to be 2 words :(
+BUF
 CCE
 CIEV
 CIND
@@ -205,6 +207,7 @@ eoc
 EP
 EPIPE
 EPMR
+epoll
 EQMID
 errno
 FB

--- a/.github/spellcheck-wordlist.txt
+++ b/.github/spellcheck-wordlist.txt
@@ -179,6 +179,8 @@ BTRH
 BTT
 bttransport
 btusb
+# aspell considers PIPE_BUF to be 2 words :(
+BUF
 CCE
 CIEV
 CIND
@@ -207,6 +209,7 @@ eoc
 EP
 EPIPE
 EPMR
+epoll
 EQMID
 errno
 EXECV

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ SPDX-License-Identifier: MIT
 - optional support for adaptive audio resampling in bluealsa-aplay
 - fix configuration for Android 13 A2DP Opus codec
 - improved ALSA PCM support for A2DP-sink, HFP-HF and HSP-HS
+- support multiple client connections to each Bluetooth PCM
 
 ## bluez-alsa v4.3.1 (2024-08-30)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ SPDX-License-Identifier: MIT
 - fix configuration for Android 13 A2DP Opus codec
 - improved ALSA PCM support for A2DP-sink, HFP-HF and HSP-HS
 - use the alsa-lib API for logging in the ALSA plugins
+- support multiple client connections to each Bluetooth PCM
 
 ## bluez-alsa v4.3.1 (2024-08-30)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ BlueALSA is designed specifically for use on small, low-powered, dedicated
 audio or audio/visual systems where the high-level audio management features of
 PulseAudio or PipeWire are not required. The target system must be able to
 function correctly with all its audio applications interfacing directly with
-ALSA, with only one application at a time using each Bluetooth audio stream.
+ALSA.
 In such systems BlueALSA adds Bluetooth audio support to the existing
 ALSA sound card support. Note this means that the applications are constrained
 by the capabilities of the ALSA API, and the higher-level audio processing

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -122,12 +122,15 @@ Re-install BlueALSA if the file is missing.
 
 ## 4. Couldn't open PCM: Device or resource busy
 
-BlueALSA supports only one client connection to each PCM. This error occurs
-when an application tries to set the hardware parameters for a PCM that is
-already in use. Note that `bluealsa-aplay` opens each PCM (of the appropriate
+BlueALSA supports only one client connection to each PCM unless the daemon
+`bluealsad` is started with the option `--multi-client`. Without that option
+set, his error occurs when an application tries to set the hardware parameters
+for a PCM that is already in use.
+Note that `bluealsa-aplay` opens each PCM (of the appropriate
 profile) as soon as it connects, and therefore attempting to use an application
 such as `arecord` to capture from BlueALSA while `bluealsa-aplay` is running
-will result in this error.
+will result in this error unless the daemon is running with multi-client support
+enabled.
 
 ## 5. Couldn't set IO thread RT priority: Operation not permitted
 

--- a/doc/bluealsad.8.rst
+++ b/doc/bluealsad.8.rst
@@ -69,6 +69,29 @@ OPTIONS
 
     Without this option, the default is to use all available HCI devices.
 
+-M[DIRECTION], --multi-client[=DIRECTION]
+    Permit multiple clients to connect to the same PCM stream.
+    Without this option, only one client can connect to a PCM.
+    With this option, for playback clients, the streams are mixed together;
+    for capture each client receives a copy of the stream.
+
+    The optional argument *DIRECTION* can be one of:
+
+    - **output** allow multiple clients only for output (playback) streams.
+    - **input** allow multiple clients only for input (capture) streams.
+    - **both** allow multiple clients for both output and input. This is the
+      default if *DIRECTION* is not specified.
+
+    See `Multiple clients`_ in the **NOTES** section below for more
+    information.
+
+--multi-attenuation=NUM
+    Reduce the amplitude of mixed streams in multi-client mode by a fixed
+    percentage *NUM* to reduce the risk of clipping. *NUM* must be an integer
+    in the range from **0** to **99**. This option is effective only when the
+    option ``--multi-client`` is given. See `Multiple clients`_ in the
+    **NOTES** section below for more information.
+
 -p NAME, --profile=NAME
     Enable *NAME* Bluetooth profile.
     May be given multiple number of times to enable multiple profiles.
@@ -457,6 +480,35 @@ control for A2DP using AVRCP, and BlueZ has not always provided robust support
 here. It is recommended to use BlueZ release 5.65 or later to be certain that
 native A2DP volume control will always be available with those devices which
 provide it.
+
+Multiple clients
+----------------
+
+Enabling the option ``--multi-client`` imposes certain limitations:
+
+- *Playback volume* - mixing multiple streams can overflow the PCM sample bit
+  depth, resulting in clipping of samples. When a PCM is running in its
+  (default) native volume control mode **bluealsad** can reduce the risk of
+  clipping by attenuating the mixed stream before encoding it. To enable this
+  feature, use the option ``--multi-attenuation`` to apply a fixed percentage
+  attenuation to the mixed PCM samples. The value given must be an integer
+  percentage in the range [0 - 99]; higher values result in greater protection
+  from clipping but also reduce the output volume. When software volume
+  control is enabled for the PCM then this attenuation is not applied, and
+  instead the user should use the BlueALSA PCM volume control to reduce volume
+  if necessary. The software volume adjustment is applied before encoding and
+  therefore has the same effect as the native volume attenuation.
+- *Playback delay* - mixing streams requires additional buffering, which may
+  increase the overall delay of the stream. The delay value reported to
+  applications is also less accurate because the client applications are not
+  synchronized and therefore their actual delay will vary slightly from the
+  reported value. This variance is small and is normally within the error
+  acceptable to watching videos, etc.
+- *Security* - in multi-user environments it is possible for two users to open
+  the same PCM, and this makes it rather trivial for one user to snoop on the
+  incoming streams of another. For this reason use of the ``--multi-client``
+  option is not recommended on such systems if they are used for voice
+  communications.
 
 FILES
 =====

--- a/misc/bash-completion/bluealsad
+++ b/misc/bash-completion/bluealsad
@@ -193,6 +193,14 @@ _bluealsad() {
 
 	local prefix list
 
+	case "$cur" in
+		--multi-client)
+			COMPREPLY=( "--multi-client=" )
+			compopt -o nospace
+			return
+			;;
+	esac
+	[[ "$prev" == "--multi-client" && "$cur" == -* ]] && prev=""
 	case "$prev" in
 		--device|-i)
 			readarray -t list < <(ls -I '*:*' /sys/class/bluetooth)
@@ -211,7 +219,7 @@ _bluealsad() {
 			readarray -t COMPREPLY < <(compgen -P "$prefix" -W "${list[*]}" -- "$cur")
 			return
 			;;
-		--loglevel|--sbc-quality|--aac-latm-version|--mp3-algorithm|--mp3-vbr-quality|--ldac-quality|--asha-side)
+		--loglevel|--sbc-quality|--aac-latm-version|--mp3-algorithm|--mp3-vbr-quality|--ldac-quality|--asha-side|--multi-client)
 			readarray -t list < <(_bluealsa_enum_values "$1" "$prev")
 			readarray -t COMPREPLY < <(compgen -W "${list[*]}" -- "$cur")
 			return
@@ -224,6 +232,11 @@ _bluealsad() {
 			[[ ${COMP_WORDS[COMP_CWORD]} = = ]] && return
 			;;
 	esac
+	if [[ "$cur" == "--multi-c"* && ${#cur} -le 12 ]] ; then
+			COMPREPLY=( "--multi-client" )
+			compopt -o nospace
+			return
+	fi
 
 	_bluealsa_complete_options "$1"
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,9 @@ libbluealsad_la_SOURCES = \
 	ba-adapter.c \
 	ba-config.c \
 	ba-device.c \
+	ba-pcm-client.c \
+	ba-pcm-mix-buffer.c \
+	ba-pcm-multi.c \
 	ba-rfcomm.c \
 	ba-transport.c \
 	ba-transport-pcm.c \

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -833,6 +833,10 @@ static int bluealsa_hw_params(snd_pcm_ioplug_t *io, snd_pcm_hw_params_t *params)
 	const unsigned int rate = io->rate;
 
 	if (pcm->ba_pcm.channels != channels || pcm->ba_pcm.rate != rate) {
+		if (pcm->ba_pcm.running) {
+			SNDERR("Couldn't change BlueALSA PCM configuration");
+			return -EINVAL;
+		}
 		debug2("Changing BlueALSA PCM configuration: %u ch, %u Hz -> %u ch, %u Hz",
 				pcm->ba_pcm.channels, pcm->ba_pcm.rate, channels, rate);
 
@@ -1725,14 +1729,28 @@ static int bluealsa_set_hw_constraint(struct bluealsa_pcm *pcm) {
 					min_p, 1024 * 1024)) < 0)
 		return err;
 
-	unsigned int list[ARRAYSIZE(codec->rates)];
-	unsigned int n;
+	/* If the PCM is already running, we must not change the codec config as
+	* that would terminate the stream for the running client */
+	if (pcm->ba_pcm.running) {
+		if ((err = snd_pcm_ioplug_set_param_minmax(io,
+					SND_PCM_IOPLUG_HW_CHANNELS, pcm->ba_pcm.channels,
+					pcm->ba_pcm.channels)) < 0)
+			return err;
+
+		if ((err = snd_pcm_ioplug_set_param_minmax(io, SND_PCM_IOPLUG_HW_RATE,
+					pcm->ba_pcm.rate, pcm->ba_pcm.rate)) < 0)
+			return err;
+
+		return 0;
+	}
 
 	/* Populate the list of supported channels and sample rates. For codecs
 	 * with fixed configuration, the list will contain only one element. For
 	 * other codecs, the list might contain all supported configurations. */
 
-	n = 0;
+	unsigned int list[ARRAYSIZE(codec->rates)];
+	unsigned int n = 0;
+
 	for (size_t i = 0; i < ARRAYSIZE(codec->channels) && codec->channels[i] != 0; i++)
 		list[n++] = codec->channels[i];
 	if ((err = snd_pcm_ioplug_set_param_list(io, SND_PCM_IOPLUG_HW_CHANNELS, n, list)) < 0)
@@ -1977,30 +1995,43 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 	}
 
 	if (codec_name[0] != '\0') {
-		/* If the codec was given, change it now, so we can get the correct
-		 * sample rate and channels for HW constraints. */
 		const char *canonical = ba_dbus_pcm_codec_get_canonical_name(codec_name);
 		const bool name_changed = strcmp(canonical, pcm->ba_pcm.codec.name) != 0;
-		if (name_changed && !ba_dbus_pcm_select_codec(&pcm->dbus_ctx, pcm->ba_pcm.pcm_path,
-					canonical, NULL, 0, 0, 0, BA_PCM_SELECT_CODEC_FLAG_NONE, &err)) {
-			SNDERR("Couldn't select BlueALSA PCM codec: %s", err.message);
-			dbus_error_free(&err);
+
+		if (pcm->ba_pcm.running) {
+			/* If the PCM is already running we must not change the codec config
+			 * as that would terminate the stream for the running client */
+			if (name_changed)
+				SNDERR("Couldn't change BlueALSA PCM codec");
+			else if (codec_config_len > 0 && (
+						pcm->ba_pcm.codec.data_len != codec_config_len ||
+						memcmp(pcm->ba_pcm.codec.data, codec_config, codec_config_len) != 0))
+				SNDERR("Couldn't change BlueALSA PCM codec configuration");
 		}
 		else {
-
-			memcpy(pcm->ba_pcm_codec_config, codec_config, codec_config_len);
-			pcm->ba_pcm_codec_config_len = codec_config_len;
-
-			/* Changing the codec may change the audio format, sample rate and/or
-			 * channels. We need to refresh our cache of PCM properties. */
-			if (name_changed && !ba_dbus_pcm_get(&pcm->dbus_ctx, &ba_addr, ba_profile,
-						stream == SND_PCM_STREAM_PLAYBACK ? BA_PCM_MODE_SINK : BA_PCM_MODE_SOURCE,
-						&pcm->ba_pcm, &err)) {
-				SNDERR("Couldn't get BlueALSA PCM: %s", err.message);
-				ret = -dbus_error_to_errno(&err);
-				goto fail;
+			/* If the codec was given, change it now, so we can get the correct
+			 * sample rate and channels for HW constraints. */
+			if (name_changed && !ba_dbus_pcm_select_codec(&pcm->dbus_ctx, pcm->ba_pcm.pcm_path,
+						canonical, NULL, 0, 0, 0, BA_PCM_SELECT_CODEC_FLAG_NONE, &err)) {
+				SNDERR("Couldn't select BlueALSA PCM codec: %s", err.message);
+				dbus_error_free(&err);
 			}
+			else {
 
+				memcpy(pcm->ba_pcm_codec_config, codec_config, codec_config_len);
+				pcm->ba_pcm_codec_config_len = codec_config_len;
+
+				/* Changing the codec may change the audio format, sample rate and/or
+				 * channels. We need to refresh our cache of PCM properties. */
+				if (name_changed && !ba_dbus_pcm_get(&pcm->dbus_ctx, &ba_addr, ba_profile,
+							stream == SND_PCM_STREAM_PLAYBACK ? BA_PCM_MODE_SINK : BA_PCM_MODE_SOURCE,
+							&pcm->ba_pcm, &err)) {
+					SNDERR("Couldn't get BlueALSA PCM: %s", err.message);
+					ret = -dbus_error_to_errno(&err);
+					goto fail;
+				}
+
+			}
 		}
 	}
 

--- a/src/asound/bluealsa-pcm.c
+++ b/src/asound/bluealsa-pcm.c
@@ -837,6 +837,10 @@ static int bluealsa_hw_params(snd_pcm_ioplug_t *io, snd_pcm_hw_params_t *params)
 	const unsigned int rate = io->rate;
 
 	if (pcm->ba_pcm.channels != channels || pcm->ba_pcm.rate != rate) {
+		if (pcm->ba_pcm.running) {
+			SNDERR("Couldn't change BlueALSA PCM configuration");
+			return -EINVAL;
+		}
 		ba_debug_pcm(pcm, "Changing BlueALSA PCM configuration: %u ch, %u Hz -> %u ch, %u Hz",
 				pcm->ba_pcm.channels, pcm->ba_pcm.rate, channels, rate);
 
@@ -1729,14 +1733,28 @@ static int bluealsa_set_hw_constraint(struct bluealsa_pcm *pcm) {
 					min_p, 1024 * 1024)) < 0)
 		return err;
 
-	unsigned int list[ARRAYSIZE(codec->rates)];
-	unsigned int n;
+	/* If the PCM is already running, we must not change the codec config as
+	* that would terminate the stream for the running client */
+	if (pcm->ba_pcm.running) {
+		if ((err = snd_pcm_ioplug_set_param_minmax(io,
+					SND_PCM_IOPLUG_HW_CHANNELS, pcm->ba_pcm.channels,
+					pcm->ba_pcm.channels)) < 0)
+			return err;
+
+		if ((err = snd_pcm_ioplug_set_param_minmax(io, SND_PCM_IOPLUG_HW_RATE,
+					pcm->ba_pcm.rate, pcm->ba_pcm.rate)) < 0)
+			return err;
+
+		return 0;
+	}
 
 	/* Populate the list of supported channels and sample rates. For codecs
 	 * with fixed configuration, the list will contain only one element. For
 	 * other codecs, the list might contain all supported configurations. */
 
-	n = 0;
+	unsigned int list[ARRAYSIZE(codec->rates)];
+	unsigned int n = 0;
+
 	for (size_t i = 0; i < ARRAYSIZE(codec->channels) && codec->channels[i] != 0; i++)
 		list[n++] = codec->channels[i];
 	if ((err = snd_pcm_ioplug_set_param_list(io, SND_PCM_IOPLUG_HW_CHANNELS, n, list)) < 0)
@@ -1984,30 +2002,42 @@ SND_PCM_PLUGIN_DEFINE_FUNC(bluealsa) {
 	}
 
 	if (codec_name[0] != '\0') {
-		/* If the codec was given, change it now, so we can get the correct
-		 * sample rate and channels for HW constraints. */
 		const char *canonical = ba_dbus_pcm_codec_get_canonical_name(codec_name);
 		const bool name_changed = strcmp(canonical, pcm->ba_pcm.codec.name) != 0;
-		if (name_changed && !ba_dbus_pcm_select_codec(&pcm->dbus_ctx, pcm->ba_pcm.pcm_path,
-					canonical, NULL, 0, 0, 0, BA_PCM_SELECT_CODEC_FLAG_NONE, &err)) {
-			snd_error(PCM, "Couldn't select BlueALSA PCM codec: %s", err.message);
-			dbus_error_free(&err);
+		if (pcm->ba_pcm.running) {
+			/* If the PCM is already running we must not change the codec config
+			 * as that would terminate the stream for the running client */
+			if (name_changed)
+				SNDERR("Couldn't change BlueALSA PCM codec");
+			else if (codec_config_len > 0 && (
+						pcm->ba_pcm.codec.data_len != codec_config_len ||
+						memcmp(pcm->ba_pcm.codec.data, codec_config, codec_config_len) != 0))
+				SNDERR("Couldn't change BlueALSA PCM codec configuration");
 		}
 		else {
-
-			memcpy(pcm->ba_pcm_codec_config, codec_config, codec_config_len);
-			pcm->ba_pcm_codec_config_len = codec_config_len;
-
-			/* Changing the codec may change the audio format, sample rate and/or
-			 * channels. We need to refresh our cache of PCM properties. */
-			if (name_changed && !ba_dbus_pcm_get(&pcm->dbus_ctx, &ba_addr, ba_profile,
-						stream == SND_PCM_STREAM_PLAYBACK ? BA_PCM_MODE_SINK : BA_PCM_MODE_SOURCE,
-						&pcm->ba_pcm, &err)) {
-				snd_error(PCM, "Couldn't get BlueALSA PCM: %s", err.message);
-				ret = -dbus_error_to_errno(&err);
-				goto fail;
+			/* If the codec was given, change it now, so we can get the correct
+			 * sample rate and channels for HW constraints. */
+			if (name_changed && !ba_dbus_pcm_select_codec(&pcm->dbus_ctx, pcm->ba_pcm.pcm_path,
+						canonical, NULL, 0, 0, 0, BA_PCM_SELECT_CODEC_FLAG_NONE, &err)) {
+				SNDERR("Couldn't select BlueALSA PCM codec: %s", err.message);
+				dbus_error_free(&err);
 			}
+			else {
 
+				memcpy(pcm->ba_pcm_codec_config, codec_config, codec_config_len);
+				pcm->ba_pcm_codec_config_len = codec_config_len;
+
+				/* Changing the codec may change the audio format, sample rate and/or
+				 * channels. We need to refresh our cache of PCM properties. */
+				if (name_changed && !ba_dbus_pcm_get(&pcm->dbus_ctx, &ba_addr, ba_profile,
+							stream == SND_PCM_STREAM_PLAYBACK ? BA_PCM_MODE_SINK : BA_PCM_MODE_SOURCE,
+							&pcm->ba_pcm, &err)) {
+					SNDERR("Couldn't get BlueALSA PCM: %s", err.message);
+					ret = -dbus_error_to_errno(&err);
+					goto fail;
+				}
+
+			}
 		}
 	}
 

--- a/src/ba-config.c
+++ b/src/ba-config.c
@@ -44,6 +44,10 @@ struct ba_config config = {
 
 	.disable_realtek_usb_fix = false,
 
+	.multi_mix_enabled = false,
+	.multi_snoop_enabled = false,
+	.multi_native_volume = 1.0,
+
 	/* CVSD is a mandatory codec */
 	.hfp.codecs.cvsd = true,
 #if ENABLE_MSBC

--- a/src/ba-config.h
+++ b/src/ba-config.h
@@ -75,6 +75,13 @@ struct ba_config {
 	/* disable alt-3 MTU for mSBC with Realtek USB adapters */
 	bool disable_realtek_usb_fix;
 
+	/* Is multi client support enabled? */
+	bool multi_mix_enabled;
+	bool multi_snoop_enabled;
+
+	/* multi client native volume attenuation */
+	double multi_native_volume;
+
 	struct {
 
 		/* available HFP codecs */

--- a/src/ba-pcm-client.c
+++ b/src/ba-pcm-client.c
@@ -1,0 +1,572 @@
+/*
+ * BlueALSA - ba-pcm-client.c
+ * SPDX-FileCopyrightText: 2016-2025 BlueALSA developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "ba-config.h"
+#include "ba-pcm-client.h"
+#include "ba-pcm-mix-buffer.h"
+#include "ba-pcm-multi.h"
+#include "ba-transport-pcm.h"
+#include "bluealsa-iface.h"
+#include "shared/log.h"
+
+/* How long to wait for drain to complete, in nanoseconds */
+#define BA_PCM_CLIENT_DRAIN_NS 300000000
+
+/* Size of the playback client input buffer */
+#define BA_CLIENT_BUFFER_PERIODS (BA_MULTI_CLIENT_THRESHOLD)
+
+static bool ba_pcm_client_is_playback(struct ba_pcm_client *client) {
+	return client->multi->pcm->mode == BA_TRANSPORT_PCM_MODE_SINK;
+}
+
+static bool ba_pcm_client_is_capture(struct ba_pcm_client *client) {
+	return client->multi->pcm->mode == BA_TRANSPORT_PCM_MODE_SOURCE;
+}
+
+/**
+ * Calculate offset in mix buffer at which to add initial samples from a client
+ * in order to align this client with the delay now reported by the multi */
+static size_t ba_pcm_client_playback_init_offset(const struct ba_pcm_client *client) {
+	const struct ba_pcm_multi *multi = client->multi;
+	const struct ba_mix_buffer *buffer = &multi->playback_buffer;
+	const size_t client_samples = client->in_offset * buffer->channels / buffer->frame_size;
+	const size_t reported_delay = ba_pcm_mix_buffer_delay(buffer, buffer->end) + (BA_MULTI_CLIENT_THRESHOLD * buffer->period);
+	return reported_delay > client_samples ? reported_delay - client_samples : reported_delay;
+}
+
+/**
+ * Perform side-effects associated with a state change. */
+static void ba_pcm_client_set_state(struct ba_pcm_client *client, enum ba_pcm_client_state new_state) {
+	pthread_mutex_lock(&client->mutex);
+	if (new_state == client->state)
+		goto unlock;
+
+	switch (new_state) {
+		case BA_PCM_CLIENT_STATE_IDLE:
+			client->drain_avail = (size_t) -1;
+			/* fallthrough */
+		case BA_PCM_CLIENT_STATE_FINISHED:
+			if (client->state == BA_PCM_CLIENT_STATE_RUNNING || client->state == BA_PCM_CLIENT_STATE_DRAINING1)
+				client->multi->active_count--;
+			break;
+		case BA_PCM_CLIENT_STATE_PAUSED:
+			if (client->state == BA_PCM_CLIENT_STATE_RUNNING && ba_pcm_client_is_capture(client))
+				client->multi->active_count--;
+			break;
+		case BA_PCM_CLIENT_STATE_RUNNING:
+			if (ba_pcm_client_is_capture(client)) {
+				if (client->state == BA_PCM_CLIENT_STATE_IDLE || client->state == BA_PCM_CLIENT_STATE_INIT || client->state == BA_PCM_CLIENT_STATE_PAUSED)
+					client->multi->active_count++;
+			}
+			else {
+				if (client->state == BA_PCM_CLIENT_STATE_IDLE) {
+					client->out_offset = -ba_pcm_client_playback_init_offset(client);
+					client->multi->active_count++;
+				}
+				else if (client->state == BA_PCM_CLIENT_STATE_DRAINING1)
+					goto unlock;
+			}
+			break;
+		case BA_PCM_CLIENT_STATE_DRAINING1:
+			break;
+		case BA_PCM_CLIENT_STATE_DRAINING2:
+			if (client->state == BA_PCM_CLIENT_STATE_DRAINING1)
+				client->multi->active_count--;
+			break;
+		default:
+			/* not reached */
+			break;
+	}
+	client->state = new_state;
+
+unlock:
+	pthread_mutex_unlock(&client->mutex);
+}
+
+/**
+ * Clean up resources associated with a client PCM connection. */
+static void ba_pcm_client_close_pcm(struct ba_pcm_client *client) {
+	if (client->pcm_fd != -1) {
+		epoll_ctl(client->multi->epoll_fd, EPOLL_CTL_DEL, client->pcm_fd, NULL);
+		client->watch = false;
+		pthread_mutex_lock(&client->mutex);
+		close(client->pcm_fd);
+		client->pcm_fd = -1;
+		pthread_mutex_unlock(&client->mutex);
+	}
+}
+
+/**
+ * Clean up resources associated with a client control connection. */
+static void ba_pcm_client_close_control(
+                                          struct ba_pcm_client *client) {
+	if (client->control_fd != -1) {
+		epoll_ctl(client->multi->epoll_fd, EPOLL_CTL_DEL, client->control_fd, NULL);
+		close(client->control_fd);
+		client->control_fd = -1;
+	}
+}
+
+/**
+ * Start/stop watching for PCM i/o events. */
+static void ba_pcm_client_watch_pcm(
+                            struct ba_pcm_client *client, bool enabled) {
+	if (client->watch == enabled)
+		return;
+
+	const uint32_t type = ba_pcm_client_is_playback(client) ? EPOLLIN : EPOLLOUT;
+	struct epoll_event event = {
+		.events = enabled ? type : 0,
+		.data.ptr = &client->pcm_event,
+	};
+	epoll_ctl(client->multi->epoll_fd, EPOLL_CTL_MOD, client->pcm_fd, &event);
+	client->watch = enabled;
+}
+
+/**
+ * Start/stop watching for drain timer expiry event. */
+static void ba_pcm_client_watch_drain(struct ba_pcm_client *client, bool enabled) {
+	struct itimerspec timeout = {
+		.it_interval = { 0 },
+		.it_value = {
+			.tv_sec = 0,
+			.tv_nsec = enabled ? BA_PCM_CLIENT_DRAIN_NS : 0,
+		},
+	};
+	timerfd_settime(client->drain_timer_fd, 0, &timeout, NULL);
+}
+
+/**
+ * Read bytes from FIFO.
+ * @return number of bytes read, 0 if buffer full, or -1 if client closed pipe */
+static ssize_t ba_pcm_client_read(struct ba_pcm_client *client) {
+
+	const size_t space = client->buffer_size - client->in_offset;
+	if (space == 0)
+		return 0;
+
+	uint8_t *buf = client->buffer + client->in_offset;
+
+	ssize_t bytes;
+	while ((bytes = read(client->pcm_fd, buf, space)) == -1 && errno == EINTR)
+		continue;
+
+	/* pipe closed by remote end */
+	if (bytes == 0)
+		return -1;
+
+	/* FIFO may be empty but client still open. */
+	if (bytes == -1 && errno == EAGAIN)
+		bytes = 0;
+
+	if (bytes > 0)
+		client->in_offset += bytes;
+
+	return bytes;
+}
+
+/**
+ * Write samples to the client fifo
+ */
+void ba_pcm_client_write(struct ba_pcm_client *client, const void *buffer, size_t samples) {
+	const uint8_t *buffer_ = buffer;
+	size_t len = samples * BA_TRANSPORT_PCM_FORMAT_BYTES(client->multi->pcm->format);
+	ssize_t ret;
+
+	do {
+		pthread_mutex_lock(&client->mutex);
+		int fd = client->pcm_fd;
+		if (fd == -1) {
+			pthread_mutex_unlock(&client->mutex);
+			return;
+		}
+		ret = write(fd, buffer_, len);
+		pthread_mutex_unlock(&client->mutex);
+
+		if (ret == -1)
+			switch (errno) {
+			case EINTR:
+				continue;
+			case EAGAIN:
+				/* If the client is so slow that the FIFO fills up, then it
+				 * is inevitable that audio frames will be eventually be
+				 * dropped in the bluetooth controller if we block here.
+				 * It is better that we discard frames here so that the
+				 * decoder is not interrupted. */
+				warn("Dropping PCM frames: %s", "PCM overrun");
+				ret = len;
+				break;
+			default:
+				/* The client has closed the pipe, or an unrecoverable error
+				 * has occurred. */
+				ba_pcm_client_close_pcm(client);
+				ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_FINISHED);
+				return;
+			}
+
+		buffer_ += ret;
+		len -= ret;
+
+	} while (len != 0);
+
+}
+
+/**
+ * Deliver samples to transport mix. */
+void ba_pcm_client_deliver(struct ba_pcm_client *client) {
+	struct ba_pcm_multi *multi = client->multi;
+
+	if (client->state != BA_PCM_CLIENT_STATE_RUNNING &&
+                           client->state != BA_PCM_CLIENT_STATE_DRAINING1)
+		return;
+
+	if (client->state == BA_PCM_CLIENT_STATE_DRAINING1) {
+		ssize_t bytes = ba_pcm_client_read(client);
+		if (bytes < 0) {
+			/* client has closed pcm connection */
+			ba_pcm_client_close_pcm(client);
+			ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_FINISHED);
+			return;
+		}
+		if (client->in_offset == 0 && errno == EAGAIN) {
+			const size_t mix_avail = ba_pcm_mix_buffer_calc_avail(&multi->playback_buffer, multi->playback_buffer.mix_offset, client->out_offset);
+			if (mix_avail == 0 || mix_avail > client->drain_avail) {
+				/* The mix buffer has completely drained all frames from
+				 * this client. We now wait some time for the bluetooth system
+				 * to play out all sent frames*/
+				ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_DRAINING2);
+				ba_pcm_client_watch_drain(client, true);
+				return;
+			}
+			else
+				client->drain_avail = mix_avail;
+		}
+	}
+
+	if (client->in_offset > 0) {
+		ssize_t delivered = ba_pcm_mix_buffer_add(&multi->playback_buffer, &client->out_offset, client->buffer, client->in_offset);
+		if (delivered > 0) {
+			memmove(client->buffer, client->buffer + delivered, client->in_offset - delivered);
+			client->in_offset -= delivered;
+
+			/* If the input buffer was full, we now have room for more. */
+			ba_pcm_client_watch_pcm(client, true);
+		}
+	}
+}
+
+/**
+ * Action taken when event occurs on client PCM playback connection. */
+static void ba_pcm_client_handle_playback_pcm(struct ba_pcm_client *client) {
+
+	ssize_t bytes = ba_pcm_client_read(client);
+	if (bytes < 0) {
+		/* client has closed pcm connection */
+		ba_pcm_client_close_pcm(client);
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_FINISHED);
+		return;
+	}
+
+	/* If buffer is full, stop reading from FIFO */
+	if (bytes == 0)
+		ba_pcm_client_watch_pcm(client, false);
+
+	/* Begin adding to mix when sufficient periods are buffered. */
+	if (client->state == BA_PCM_CLIENT_STATE_IDLE) {
+		if (client->in_offset >= BA_MULTI_CLIENT_THRESHOLD * client->multi->period_bytes)
+			ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_RUNNING);
+	}
+}
+
+/**
+ * Action client Drain request.
+ *
+ * Starts drain timer. */
+static void ba_pcm_client_begin_drain(
+                                          struct ba_pcm_client *client) {
+	debug("DRAIN: client %zu", client->id);
+	if (ba_pcm_client_is_playback(client) && client->state == BA_PCM_CLIENT_STATE_RUNNING) {
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_DRAINING1);
+		ba_pcm_client_watch_pcm(client, false);
+	}
+	else {
+		if (write(client->control_fd, "OK", 2) != 2)
+			error("client control response failed");
+	}
+}
+
+/**
+ * Action client Drop request. */
+static void ba_pcm_client_drop(struct ba_pcm_client *client) {
+	debug("DROP: client %zu", client->id);
+	if (ba_pcm_client_is_playback(client)) {
+		ba_pcm_client_watch_drain(client, false);
+		splice(client->pcm_fd, NULL, config.null_fd, NULL, 1024 * 32, SPLICE_F_NONBLOCK);
+		client->in_offset = 0;
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_IDLE);
+		client->drop = true;
+	}
+}
+
+/**
+ * Action client Pause request. */
+static void ba_pcm_client_pause(struct ba_pcm_client *client) {
+	debug("PAUSE: client %zu", client->id);
+	ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_PAUSED);
+	ba_pcm_client_watch_pcm(client, false);
+	if (ba_pcm_client_is_playback(client)) {
+		struct ba_mix_buffer *buffer = &client->multi->playback_buffer;
+		client->out_offset = -ba_pcm_mix_buffer_delay(buffer, client->out_offset);
+	}
+}
+
+/**
+ * Action client Resume request. */
+static void ba_pcm_client_resume(struct ba_pcm_client *client) {
+	debug("RESUME: client %zu", client->id);
+	if (client->state == BA_PCM_CLIENT_STATE_IDLE) {
+		if (ba_pcm_client_is_playback(client)) {
+			ba_pcm_client_watch_pcm(client, true);
+			client->drop = false;
+		}
+		else
+			ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_RUNNING);
+	}
+	if (client->state == BA_PCM_CLIENT_STATE_PAUSED) {
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_RUNNING);
+		if (ba_pcm_client_is_playback(client))
+			ba_pcm_client_watch_pcm(client, true);
+	}
+}
+
+/**
+ * Action taken when drain timer expires. */
+static void ba_pcm_client_handle_drain(struct ba_pcm_client *client) {
+	debug("DRAIN COMPLETE: client %zu", client->id);
+	if (client->state != BA_PCM_CLIENT_STATE_DRAINING2)
+		return;
+
+	ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_IDLE);
+	ba_pcm_client_watch_drain(client, false);
+	ba_pcm_client_watch_pcm(client, true);
+	client->in_offset = 0;
+	if (write(client->control_fd, "OK", 2) != 2)
+		error("client control response failed");
+}
+
+/**
+ * Action taken when event occurs on client control connection. */
+static void ba_pcm_client_handle_control(struct ba_pcm_client *client) {
+	char command[6];
+	ssize_t len;
+	do {
+		len = read(client->control_fd, command, sizeof(command));
+	} while (len == -1 && errno == EINTR);
+
+	if (len == -1) {
+		if (errno == EAGAIN)
+			return;
+	}
+
+	if (len <= 0) {
+		ba_pcm_client_close_control(client);
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_FINISHED);
+		return;
+	}
+
+	if (client->state == BA_PCM_CLIENT_STATE_DRAINING1 ||
+			client->state == BA_PCM_CLIENT_STATE_DRAINING2) {
+	/* Should not happen - a well-behaved client will block during drain.
+	 * However, not all clients are well behaved. So we invoke the
+	 * drain complete handler before processing this request.*/
+		ba_pcm_client_handle_drain(client);
+	}
+
+	if (strncmp(command, BLUEALSA_PCM_CTRL_DRAIN, len) == 0) {
+		ba_pcm_client_begin_drain(client);
+	}
+	else if (strncmp(command, BLUEALSA_PCM_CTRL_DROP, len) == 0) {
+		ba_pcm_client_drop(client);
+		len = write(client->control_fd, "OK", 2);
+	}
+	else if (strncmp(command, BLUEALSA_PCM_CTRL_PAUSE, len) == 0) {
+		ba_pcm_client_pause(client);
+		len = write(client->control_fd, "OK", 2);
+	}
+	else if (strncmp(command, BLUEALSA_PCM_CTRL_RESUME, len) == 0) {
+		ba_pcm_client_resume(client);
+		len = write(client->control_fd, "OK", 2);
+	}
+	else {
+		warn("Invalid PCM control command: %*s", (int)len, command);
+		len = write(client->control_fd, "Invalid", 7);
+	}
+}
+
+/**
+ * Marshall client events.
+ * Invokes appropriate action. */
+void ba_pcm_client_handle_event(struct ba_pcm_client_event *event) {
+	struct ba_pcm_client *client = event->client;
+	switch(event->type) {
+		case BA_EVENT_TYPE_PCM:
+			if (ba_pcm_client_is_playback(client))
+				ba_pcm_client_handle_playback_pcm(client);
+			break;
+		case BA_EVENT_TYPE_CONTROL:
+			ba_pcm_client_handle_control(client);
+			break;
+		case BA_EVENT_TYPE_DRAIN:
+			ba_pcm_client_handle_drain(client);
+			break;
+	}
+}
+
+void ba_pcm_client_handle_close_event(
+                                     struct ba_pcm_client_event *event) {
+	struct ba_pcm_client *client = event->client;
+	switch (event->type) {
+		case BA_EVENT_TYPE_PCM:
+			ba_pcm_client_close_pcm(client);
+			break;
+		case BA_EVENT_TYPE_CONTROL:
+			ba_pcm_client_close_control(client);
+			break;
+		default:
+			g_assert_not_reached();
+	}
+	ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_FINISHED);
+}
+
+/**
+ * Called when a running playback pcm fails to transfer audio frames in time
+ * to prevent mix buffer becoming empty. */
+void ba_pcm_client_underrun(struct ba_pcm_client *client) {
+	if (client->state == BA_PCM_CLIENT_STATE_RUNNING) {
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_IDLE);
+		debug("client %zu underrun", client->id);
+	}
+}
+
+/**
+ * Allocate a buffer suitable for transport transfer size, and set initial
+ * state. */
+bool ba_pcm_client_init(struct ba_pcm_client *client) {
+	struct ba_pcm_multi *multi = client->multi;
+
+	if (ba_pcm_client_is_playback(client)) {
+		client->buffer_size = BA_CLIENT_BUFFER_PERIODS * multi->period_bytes;
+
+		client->buffer = calloc(client->buffer_size, sizeof(uint8_t));
+		if (client->buffer == NULL) {
+			error("Unable to allocate client buffer: %s", strerror(errno));
+			return false;
+		}
+
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_IDLE);
+		ba_pcm_client_watch_pcm(client, true);
+	}
+	else {
+		/* Capture clients are active immediately. */
+		ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_RUNNING);
+	}
+
+	return true;
+}
+
+/**
+ * Allocate a new client instance. */
+struct ba_pcm_client *ba_pcm_client_new(struct ba_pcm_multi *multi, int pcm_fd, int control_fd) {
+	struct ba_pcm_client *client = calloc(1, sizeof(struct ba_pcm_client));
+	if (!client) {
+		error("Unable to create new client: %s", strerror(errno));
+		return NULL;
+	}
+
+	client->multi = multi;
+	client->pcm_fd = pcm_fd;
+	client->control_fd = control_fd;
+	client->drain_timer_fd = -1;
+	pthread_mutex_init(&client->mutex, NULL);
+
+	client->pcm_event.type = BA_EVENT_TYPE_PCM;
+	client->pcm_event.client = client;
+	client->control_event.type = BA_EVENT_TYPE_CONTROL;
+	client->control_event.client = client;
+
+	struct epoll_event ep_event = {
+		.data.ptr = &client->pcm_event,
+	 };
+
+	if (epoll_ctl(multi->epoll_fd, EPOLL_CTL_ADD, client->pcm_fd, &ep_event) == -1) {
+		error("Unable to init client, epoll_ctl: %s\n", strerror(errno));
+		ba_pcm_client_free(client);
+		return NULL;
+	}
+
+	ep_event.data.ptr = &client->control_event;
+	ep_event.events = EPOLLIN;
+	if (epoll_ctl(multi->epoll_fd, EPOLL_CTL_ADD, client->control_fd, &ep_event) == -1) {
+		error("Unable to init client, epoll_ctl: %s\n", strerror(errno));
+		epoll_ctl(multi->epoll_fd, EPOLL_CTL_DEL, client->pcm_fd, NULL);
+		ba_pcm_client_free(client);
+		return NULL;
+	}
+
+	if (ba_pcm_client_is_playback(client)) {
+		client->drain_timer_fd = timerfd_create(CLOCK_MONOTONIC, 0);
+		client->drain_event.type = BA_EVENT_TYPE_DRAIN;
+		client->drain_event.client = client;
+
+		ep_event.data.ptr = &client->drain_event;
+		ep_event.events = EPOLLIN;
+		if (epoll_ctl(multi->epoll_fd, EPOLL_CTL_ADD, client->drain_timer_fd, &ep_event) == -1) {
+			error("Unable to init client, epoll_ctl: %s", strerror(errno));
+			epoll_ctl(multi->epoll_fd, EPOLL_CTL_DEL, client->pcm_fd, NULL);
+			epoll_ctl(multi->epoll_fd, EPOLL_CTL_DEL, client->control_fd, NULL);
+			ba_pcm_client_free(client);
+			return NULL;
+		}
+
+	}
+
+	client->watch = false;
+	client->state = BA_PCM_CLIENT_STATE_INIT;
+
+	return client;
+}
+
+/**
+ * Free the resources used by a client. */
+void ba_pcm_client_free(struct ba_pcm_client *client) {
+	if (ba_pcm_client_is_playback(client)) {
+		epoll_ctl(client->multi->epoll_fd, EPOLL_CTL_DEL, client->drain_timer_fd, NULL);
+		if (client->drain_timer_fd >= 0)
+			close(client->drain_timer_fd);
+		free(client->buffer);
+	}
+	ba_pcm_client_close_pcm(client);
+	ba_pcm_client_close_control(client);
+	ba_pcm_client_set_state(client, BA_PCM_CLIENT_STATE_FINISHED);
+	pthread_mutex_destroy(&client->mutex);
+	free(client);
+}

--- a/src/ba-pcm-client.h
+++ b/src/ba-pcm-client.h
@@ -1,0 +1,97 @@
+/*
+ * BlueALSA - ba-pcm-client.h
+ * SPDX-FileCopyrightText: 2016-2025 BlueALSA developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+#ifndef BLUEALSA_BAPCMCLIENT_H_
+#define BLUEALSA_BAPCMCLIENT_H_
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+#include "ba-pcm-multi.h"
+#include "config.h"
+
+enum ba_pcm_client_state {
+	/* client is registered, but not yet initialized */
+	BA_PCM_CLIENT_STATE_INIT = 0,
+	/* client is initialized, but not active */
+	BA_PCM_CLIENT_STATE_IDLE,
+	/* client is transferring audio frames */
+	BA_PCM_CLIENT_STATE_RUNNING,
+	/* client has sent PAUSE command, waiting for RESUME */
+	BA_PCM_CLIENT_STATE_PAUSED,
+	/* client has sent DRAIN command, processing frames remaining in the pipe */
+	BA_PCM_CLIENT_STATE_DRAINING1,
+	/* pipe is drained, waiting on timeout before returning to IDLE */
+	BA_PCM_CLIENT_STATE_DRAINING2,
+	/* client has closed pipe and/or control socket */
+	BA_PCM_CLIENT_STATE_FINISHED,
+};
+
+enum ba_pcm_client_event_type {
+	BA_EVENT_TYPE_PCM,
+	BA_EVENT_TYPE_CONTROL,
+	BA_EVENT_TYPE_DRAIN,
+};
+
+struct ba_pcm_client_event {
+	enum ba_pcm_client_event_type type;
+	struct ba_pcm_client *client;
+};
+
+struct ba_pcm_client {
+	struct ba_pcm_multi *multi;
+	/* pcm pipe endpoint */
+	int pcm_fd;
+	/* control socket endpoint */
+	int control_fd;
+	/* timer for drain completion */
+	int drain_timer_fd;
+	/* event structures for i/o scheduling */
+	struct ba_pcm_client_event pcm_event;
+	struct ba_pcm_client_event control_event;
+	struct ba_pcm_client_event drain_event;
+	enum ba_pcm_client_state state;
+	/* pcm sample input buffer */
+	uint8_t *buffer;
+	size_t buffer_size;
+	/* position of next free byte in pcm input buffer */
+	size_t in_offset;
+	/* position in mix buffer of next transfer */
+	intmax_t out_offset;
+	/* number of frames in mix buffer from this client yet to be drained */
+	size_t drain_avail;
+	/* flag indicating a Drop request has been received */
+	bool drop;
+	/* flag indicating the client is watching for I/O events on PCM pipe */
+	bool watch;
+	/* guard access to the PCM pipe endpoint */
+	pthread_mutex_t mutex;
+#if DEBUG
+	/* when debugging use this as identifier in log messages */
+	size_t id;
+#endif
+};
+
+struct ba_pcm_client *ba_pcm_client_new(
+					struct ba_pcm_multi *multi,
+					int pcm_fd, int control_fd);
+
+bool ba_pcm_client_init(struct ba_pcm_client *client);
+
+void ba_pcm_client_free(struct ba_pcm_client *client);
+
+void ba_pcm_client_handle_event(struct ba_pcm_client_event *event);
+void ba_pcm_client_handle_close_event(struct ba_pcm_client_event *event);
+void ba_pcm_client_deliver(struct ba_pcm_client *client);
+void ba_pcm_client_fetch(struct ba_pcm_client *client);
+void ba_pcm_client_write(struct ba_pcm_client *client, const void *buffer, size_t samples);
+void ba_pcm_client_drain(struct ba_pcm_client *client);
+void ba_pcm_client_underrun(struct ba_pcm_client *client);
+
+#endif

--- a/src/ba-pcm-mix-buffer.c
+++ b/src/ba-pcm-mix-buffer.c
@@ -1,0 +1,378 @@
+/*
+ * BlueALSA - ba-mix-buffer.c
+ * SPDX-FileCopyrightText: 2016-2025 BlueALSA developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <endian.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ba-transport-pcm.h"
+#include "shared/log.h"
+#include "ba-pcm-mix-buffer.h"
+#include "ba-pcm-multi.h"
+
+#define BA_24BIT_MIN (int32_t)0xFF800000
+#define BA_24BIT_MAX (int32_t)0x007FFFFF
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+
+#define BA_S16_2LE_TO_INT32(x) (x)
+#define BA_S32_4LE_TO_INT64(x) (x)
+#define BA_S24_4LE_TO_INT32(x) (int32_t)((x & 0x00800000) ? x | 0xFF000000 : x)
+#define BA_INT32_TO_S24_4LE(x) (uint32_t)(((uint32_t)x & 0x80000000) >> 8) | ((uint32_t)x & 0x007FFFFF)
+
+#elif __BYTE_ORDER == __BIG_ENDIAN
+
+#include <byteswap.h>
+#define BA_S16_2LE_TO_INT32(x) (int16_t)bswap_16(x)
+#define BA_S32_4LE_TO_INT64(x) (int32_t)bswap_32(x)
+
+#define BA_S24_LE_TO_INT32(x) ( \
+	((uint32_t)x & 0xFF000000) >> 24 | \
+	((uint32_t)x & 0x00FF0000) >> 8 | \
+	((uint32_t)x & 0x0000FF00) << 8 | \
+	((x & 0x00008000) ? 0xFF : 0x00))
+
+#define BA_INT32_TO_S24_4LE(x) ( \
+	((x & 0x80000000) ? 0xFF : 0x00)) | \
+	((uint32_t)x & 0x00FF0000) >> 8 | \
+	((uint32_t)x & 0x0000FF00) << 8 | \
+	((uint32_t)x & 0x000000FF) << 24
+
+#else
+# error "Unknown byte order"
+#endif
+
+/**
+ * Configure the mix buffer for use with given transport stream parameters.
+ *
+ * @param buffer Pointer to the buffer that is to be configured.
+ * @param format The sample format that will be used.
+ * @param channels The number of channels in each frame.
+ * @param buffer_frames The requested capacity of the buffer, in frames.
+ * @param period_frames The number of frames to be transferred at one time.*/
+int ba_pcm_mix_buffer_init(struct ba_mix_buffer *buffer,
+				uint16_t format, uint8_t channels,
+				size_t buffer_frames, size_t period_frames) {
+	buffer->format = format;
+	buffer->channels = channels;
+	buffer->size = buffer_frames * channels;
+	buffer->period = period_frames * channels;
+	buffer->mix_offset = 0;
+	buffer->end = 0;
+	switch(format) {
+		case BA_TRANSPORT_PCM_FORMAT_U8:
+			buffer->frame_size = channels * sizeof(uint8_t);
+			buffer->data.s16 = calloc(buffer->size, sizeof(int16_t));
+			break;
+		case BA_TRANSPORT_PCM_FORMAT_S16_2LE:
+			buffer->frame_size = channels * sizeof(int16_t);
+			buffer->data.s32 = calloc(buffer->size, sizeof(int32_t));
+			break;
+		case BA_TRANSPORT_PCM_FORMAT_S24_4LE:
+			buffer->frame_size = channels * sizeof(int32_t);
+			buffer->data.s32 = calloc(buffer->size, sizeof(int32_t));
+			break;
+		case BA_TRANSPORT_PCM_FORMAT_S32_4LE:
+			buffer->frame_size = channels * sizeof(int32_t);
+			buffer->data.s64 = calloc(buffer->size, sizeof(int64_t));
+			break;
+		default:
+			error("Invalid format %u", format);
+			return -1;
+			break;
+	}
+	if (buffer->data.any == NULL) {
+		error("Out of memory");
+		return -1;
+	}
+	return 0;
+}
+
+/**
+ * Release the resources used by a mix buffer. */
+void ba_pcm_mix_buffer_release(struct ba_mix_buffer *buffer) {
+	buffer->size = 0;
+	free(buffer->data.any);
+	buffer->data.any = NULL;
+}
+
+/**
+ * The number of samples that can be read from start offset to end offset.
+ *
+ * @param start offset of first sample to be read.
+ * @param end   offset of sample after the last one to be read. */
+size_t ba_pcm_mix_buffer_calc_avail(const struct ba_mix_buffer *buffer, size_t start, size_t end) {
+	if (end >= start)
+		return end - start;
+	else
+		return buffer->size + end - start;
+}
+
+/**
+ * Is the buffer empty ? */
+bool ba_pcm_mix_buffer_empty(const struct ba_mix_buffer *buffer) {
+	return buffer->mix_offset == buffer->end;
+}
+
+/**
+ * The delay, expressed in samples, that would be incurred by adding the next
+ * frame at the given offset. */
+size_t ba_pcm_mix_buffer_delay(const struct ba_mix_buffer *buffer, size_t offset) {
+	return ba_pcm_mix_buffer_calc_avail(buffer, buffer->mix_offset, offset);
+}
+
+/**
+ * true if the number of frames available to be read is greater than the
+ * start threshold. */
+bool ba_pcm_mix_buffer_at_threshold(struct ba_mix_buffer *buffer) {
+	size_t avail = ba_pcm_mix_buffer_calc_avail(buffer, buffer->mix_offset, buffer->end);
+	return avail >= BA_MULTI_MIX_THRESHOLD * buffer->period;
+}
+
+/**
+ * Add a stream of bytes from a client into the mix.
+ *
+ * @param offset Current position of this client in the mix buffer. To be
+ *        stored between calls. A negative value is interpreted as relative to
+ *        (ahead of) the current mix offset.
+ * @param data Pointer to the byte stream.
+ * @param bytes The number of bytes in the stream.
+ * @return The number of bytes actually added into the mix. This value is always
+ *         a whole number of frames. */
+size_t ba_pcm_mix_buffer_add(struct ba_mix_buffer *restrict buffer, intmax_t *restrict offset, const void *restrict data, size_t bytes) {
+
+	size_t start;
+	size_t mix_offset = buffer->mix_offset;
+	/* Save the initial buffer fill level so that we can detect if this
+	 * addition has increased it. */
+	size_t avail = ba_pcm_mix_buffer_calc_avail(buffer, mix_offset, buffer->end);
+
+	/* Only allow complete frames into the mix. */
+	size_t frames = bytes / buffer->frame_size;
+	size_t samples = frames * buffer->channels;
+
+	/* convert relative offset to absolute value */
+	if (*offset < 0) {
+		if (-*offset > (intmax_t)buffer->size)
+			*offset = mix_offset - 1;
+		else
+			*offset = mix_offset - *offset;
+	}
+
+	start = *offset;
+	if (start >= buffer->size)
+		start %= buffer->size;
+
+	if (start < mix_offset)
+		start += buffer->size;
+
+	/* To keep all clients as closely synchronized as possible, do not
+	 * allow any client to advance more than the mix threshold ahead of
+	 * the current read position. */
+	const size_t limit = mix_offset + BA_MULTI_MIX_THRESHOLD * buffer->period;
+	if (start >= limit)
+		return 0;
+
+	if (start + samples > limit)
+		samples = limit - start;
+
+	for (size_t n = 0; n < samples; n++) {
+		if (start + n >= buffer->size)
+			start -= buffer->size;
+		switch (buffer->format) {
+			case BA_TRANSPORT_PCM_FORMAT_U8: {
+				uint8_t *ptr = (uint8_t*)data;
+				buffer->data.s16[start + n] += ptr[n] - 0x80;
+				break;
+			}
+			case BA_TRANSPORT_PCM_FORMAT_S16_2LE: {
+				const int16_t *ptr = (const int16_t*)data;
+				buffer->data.s32[start + n] += BA_S16_2LE_TO_INT32(ptr[n]);
+				break;
+			}
+			case BA_TRANSPORT_PCM_FORMAT_S24_4LE: {
+				const uint32_t *ptr = (const uint32_t*)data;
+				buffer->data.s32[start + n] += BA_S24_4LE_TO_INT32(ptr[n]);
+				break;
+			}
+			case BA_TRANSPORT_PCM_FORMAT_S32_4LE: {
+				const int32_t *ptr = (const int32_t*)data;
+				buffer->data.s64[start + n] += BA_S32_4LE_TO_INT64(ptr[n]);
+				break;
+			}
+		}
+	}
+
+	start += samples;
+	if (start >= buffer->size)
+		start -= buffer->size;
+	*offset = start;
+
+	/* If this addition has increased the number of available frames, update
+	 * the end pointer. */
+	if (ba_pcm_mix_buffer_calc_avail(buffer, mix_offset, *offset) > avail)
+		buffer->end = *offset;
+
+	/* return number of bytes consumed from client */
+	return samples * buffer->frame_size / buffer->channels;
+}
+
+/**
+ * Read mixed frames from the mix buffer.
+ *
+ * Applies volume scaling to the samples returned.
+ *
+ * @param data Pointer to a buffer in which to place the frames.
+ * @param frames Size of the data buffer in samples.
+ * @param scale An array of scaling factors, one for each channel of the stream.
+ * @return number of samples fetched from mix. This is always complete frames.
+ * */
+size_t ba_pcm_mix_buffer_read(struct ba_mix_buffer *restrict buffer, void *restrict data, size_t samples, double *restrict scale) {
+
+	size_t start = buffer->mix_offset;
+	size_t end = buffer->end;
+	/* Only process complete frames */
+	samples -= samples % buffer->channels;
+
+	/* Limit each read to 1 period. */
+	if (samples > buffer->period)
+		samples = buffer->period;
+
+	/* Do not read beyond the last sample written. */
+	size_t avail = ba_pcm_mix_buffer_calc_avail(buffer, start, end);
+	if (samples > avail)
+		samples = avail;
+
+	size_t out_offset = 0;
+	size_t n;
+	for (n = 0; n < samples; n += buffer->channels) {
+		if (start + n >= buffer->size)
+			start -= buffer->size;
+		switch (buffer->format) {
+			case BA_TRANSPORT_PCM_FORMAT_U8: {
+				uint8_t *dest = (uint8_t*) data;
+				int16_t *sample = buffer->data.s16 + start + n;
+				int channel;
+				for (channel = 0; channel < buffer->channels; channel++) {
+					if (scale[channel] == 0.0) {
+						sample[channel] = 0;
+					}
+					else {
+						sample[channel] *= scale[channel];
+						if (sample[channel] > INT8_MAX)
+							sample[channel] = INT8_MAX;
+						else if (sample[channel] < INT8_MIN)
+							sample[channel] = INT8_MIN;
+					}
+					dest[out_offset++] =
+                               0x80 + (int8_t)htole16((uint8_t)sample[channel]);
+					sample[channel] = 0;
+				}
+				break;
+			}
+			case BA_TRANSPORT_PCM_FORMAT_S16_2LE: {
+				int16_t *dest = (int16_t*) data;
+				int32_t *sample = buffer->data.s32 + start + n;
+				int channel;
+				for (channel = 0; channel < buffer->channels; channel++) {
+					if (scale[channel] == 0.0) {
+						sample[channel] = 0;
+					}
+					else {
+						if (scale[channel] < 0.99)
+							sample[channel] *= scale[channel];
+						if (sample[channel] > INT16_MAX)
+							sample[channel] = INT16_MAX;
+						else if (sample[channel] < INT16_MIN)
+							sample[channel] = INT16_MIN;
+					}
+					dest[out_offset++] =
+                                    (int16_t)htole16((uint16_t)sample[channel]);
+					sample[channel] = 0;
+				}
+				break;
+			}
+			case BA_TRANSPORT_PCM_FORMAT_S24_4LE: {
+				uint32_t *dest = (uint32_t*) data;
+				int32_t *sample = buffer->data.s32 + start + n;
+				int channel;
+				for (channel = 0; channel < buffer->channels; channel++) {
+					if (scale[channel] == 0.0) {
+						sample[channel] = 0;
+					}
+					else {
+						sample[channel] *= scale[channel];
+						if (sample[channel] > BA_24BIT_MAX)
+							sample[channel] = BA_24BIT_MAX;
+						else if (sample[channel] < BA_24BIT_MIN)
+							sample[channel] = BA_24BIT_MIN;
+					}
+					dest[out_offset++] =
+                       (uint32_t)BA_INT32_TO_S24_4LE(sample[channel]);
+					sample[channel] = 0;
+				}
+				break;
+			}
+			case BA_TRANSPORT_PCM_FORMAT_S32_4LE: {
+				int32_t *dest = (int32_t*) data;
+				int64_t *sample = buffer->data.s64 + start + n;
+				int channel;
+				for (channel = 0; channel < buffer->channels; channel++) {
+					if (scale[channel] == 0.0) {
+						sample[channel] = 0;
+					}
+					else {
+						sample[channel] *= scale[channel];
+						if (sample[channel] > INT32_MAX)
+							sample[channel] = INT32_MAX;
+						else if (sample[channel] < INT32_MIN)
+							sample[channel] = INT32_MIN;
+					}
+					dest[out_offset++] =
+                                    (int32_t)htole32((uint32_t)sample[channel]);
+					sample[channel] = 0;
+				}
+				break;
+			}
+		}
+	}
+
+	start += n;
+	if (start >= buffer->size)
+		start -= buffer->size;
+	buffer->mix_offset = start;
+
+	return samples;
+}
+
+/**
+ * Discard all frames from the mix buffer. */
+void ba_pcm_mix_buffer_clear(struct ba_mix_buffer *buffer) {
+	buffer->mix_offset = 0;
+	buffer->end = 0;
+	size_t buffer_bytes;
+	switch(buffer->format) {
+		case BA_TRANSPORT_PCM_FORMAT_U8:
+			buffer_bytes = buffer->size * sizeof(int16_t);
+			break;
+		case BA_TRANSPORT_PCM_FORMAT_S16_2LE:
+		case BA_TRANSPORT_PCM_FORMAT_S24_4LE:
+			buffer_bytes = buffer->size * sizeof(int32_t);
+			break;
+		case BA_TRANSPORT_PCM_FORMAT_S32_4LE:
+			buffer_bytes = buffer->size * sizeof(int64_t);
+			break;
+		default:
+			/* not reached */
+			buffer_bytes = 0;
+	}
+	memset(buffer->data.any, 0, buffer_bytes);
+}

--- a/src/ba-pcm-mix-buffer.h
+++ b/src/ba-pcm-mix-buffer.h
@@ -1,0 +1,58 @@
+/*
+ * BlueALSA - ba-mix-buffer.h
+ * SPDX-FileCopyrightText: 2016-2025 BlueALSA developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+#ifndef BLUEALSA_BAMIXBUFFER_H_
+#define BLUEALSA_BAMIXBUFFER_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+struct ba_mix_buffer {
+	/* sample format */
+	uint16_t format;
+	uint8_t channels;
+	/* physical bytes per frame */
+	uint16_t frame_size;
+	/* array storing the mixed frames */
+	union {
+		int16_t *s16;
+		int32_t *s32;
+		int64_t *s64;
+		void *any;
+	} data;
+	/* Capacity of the buffer in samples */
+	size_t size;
+	/* The number of samples to be transferred  at one time */
+	size_t period;
+	/* Position of next read from the mix */
+	_Atomic size_t mix_offset;
+	/* Postion after last sample written to the mix */
+	size_t end;
+};
+
+int ba_pcm_mix_buffer_init(struct ba_mix_buffer *buffer,
+				uint16_t format, uint8_t channels,
+				size_t buffer_frames, size_t period_frames);
+
+void ba_pcm_mix_buffer_release(struct ba_mix_buffer *buffer);
+
+bool ba_pcm_mix_buffer_at_threshold(struct ba_mix_buffer *buffer);
+
+size_t ba_pcm_mix_buffer_calc_avail(const struct ba_mix_buffer *buffer, size_t start, size_t end);
+bool ba_pcm_mix_buffer_empty(const struct ba_mix_buffer *buffer);
+size_t ba_pcm_mix_buffer_delay(const struct ba_mix_buffer *buffer, size_t offset);
+
+size_t ba_pcm_mix_buffer_add(struct ba_mix_buffer *buffer,
+				intmax_t *offset, const void *data, size_t bytes);
+
+size_t ba_pcm_mix_buffer_read(struct ba_mix_buffer *buffer,
+				void *data, size_t frames, double *scale);
+
+void ba_pcm_mix_buffer_clear(struct ba_mix_buffer *buffer);
+
+#endif

--- a/src/ba-pcm-multi.c
+++ b/src/ba-pcm-multi.c
@@ -1,0 +1,684 @@
+/*
+ * BlueALSA - ba-pcm-multi.c
+ * SPDX-FileCopyrightText: 2016-2025 BlueALSA developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <errno.h>
+#include <glib.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include "ba-config.h"
+#include "ba-pcm-client.h"
+#include "ba-pcm-multi.h"
+#include "ba-transport-pcm.h"
+#include "ba-transport.h"
+#include "shared/log.h"
+#include "shared/defs.h"
+
+
+/* Limit number of clients to ensure sufficient resources are available. */
+#define BA_MULTI_MAX_CLIENTS 32
+
+/* Size of epoll event array. Allow for client control, pcm, and drain timer,
+ * plus the mix event fd. */
+#define BA_MULTI_MAX_EVENTS (1 + BA_MULTI_MAX_CLIENTS * 3)
+
+/* Determines the size of the mix buffer. */
+#define BA_MULTI_BUFFER_PERIODS 16
+
+/* Internal period time */
+#define BA_MULTI_PERIOD_MS 20
+
+static void *ba_pcm_mix_thread_func(struct ba_pcm_multi *multi);
+static void *ba_pcm_snoop_thread_func(struct ba_pcm_multi *multi);
+static void ba_pcm_multi_remove_client(struct ba_pcm_multi *multi, struct ba_pcm_client *client);
+
+
+static bool ba_pcm_multi_is_source(const struct ba_pcm_multi *multi) {
+	return multi->pcm->mode == BA_TRANSPORT_PCM_MODE_SOURCE;
+}
+
+static bool ba_pcm_multi_is_sink(const struct ba_pcm_multi *multi) {
+	return multi->pcm->mode == BA_TRANSPORT_PCM_MODE_SINK;
+}
+
+static bool ba_pcm_multi_is_target(const struct ba_pcm_multi *multi) {
+	return multi->pcm->t->profile & (BA_TRANSPORT_PROFILE_A2DP_SINK | BA_TRANSPORT_PROFILE_MASK_HF);
+}
+
+static void ba_pcm_multi_cleanup(struct ba_pcm_multi *multi) {
+	if (multi->thread != config.main_thread) {
+		eventfd_write(multi->event_fd, 0xDEAD0000);
+		pthread_join(multi->thread, NULL);
+		multi->thread = config.main_thread;
+	}
+	if (ba_pcm_multi_is_sink(multi) && multi->playback_buffer.size > 0)
+		ba_pcm_mix_buffer_release(&multi->playback_buffer);
+
+	pthread_mutex_lock(&multi->client_mutex);
+	while (multi->client_count > 0)
+		ba_pcm_multi_remove_client(multi, g_list_first(multi->clients)->data);
+	multi->client_count = 0;
+	pthread_mutex_unlock(&multi->client_mutex);
+}
+
+static void ba_pcm_multi_init_clients(struct ba_pcm_multi *multi) {
+	pthread_mutex_lock(&multi->client_mutex);
+	GList *el;
+	for (el = multi->clients; el != NULL; el = el->next) {
+		struct ba_pcm_client *client = el->data;
+		if (client->buffer == NULL) {
+			if (!ba_pcm_client_init(client))
+				ba_pcm_multi_remove_client(client->multi, client);
+		}
+	}
+	pthread_mutex_unlock(&multi->client_mutex);
+}
+
+static void ba_pcm_multi_underrun(struct ba_pcm_multi *multi) {
+	pthread_mutex_lock(&multi->client_mutex);
+	GList *el;
+	for (el = multi->clients; el != NULL; el = el->next) {
+		struct ba_pcm_client *client = el->data;
+		ba_pcm_client_underrun(client);
+	}
+	pthread_mutex_unlock(&multi->client_mutex);
+}
+
+/**
+ * Start the multi client thread. */
+static bool ba_pcm_multi_start(struct ba_pcm_multi *multi) {
+
+	if (ba_pcm_multi_is_sink(multi)) {
+		if (pthread_create(&multi->thread, NULL, PTHREAD_FUNC(ba_pcm_mix_thread_func), multi) == -1) {
+			error("Cannot create pcm multi mix thread: %s", strerror(errno));
+			ba_pcm_mix_buffer_release(&multi->playback_buffer);
+			multi->thread = config.main_thread;
+			return false;
+		}
+		pthread_setname_np(multi->thread, "ba-pcm-mix");
+	}
+	else {
+		if (pthread_create(&multi->thread, NULL, PTHREAD_FUNC(ba_pcm_snoop_thread_func), multi) == -1) {
+			error("Cannot create pcm multi snoop thread: %s", strerror(errno));
+			multi->thread = config.main_thread;
+			return false;
+		}
+		pthread_setname_np(multi->thread, "ba-pcm-snoop");
+	}
+
+	return true;
+}
+
+/**
+ * Is multi-client support implemented and configured for the given
+ * transport pcm ? */
+bool ba_pcm_multi_enabled(const struct ba_transport_pcm *pcm) {
+	if (config.multi_mix_enabled && pcm->mode == BA_TRANSPORT_PCM_MODE_SINK) {
+		if (BA_TRANSPORT_PROFILE_IS_MEDIA_A2DP(pcm->t))
+			return pcm->format != BA_TRANSPORT_PCM_FORMAT_S24_3LE;
+		return true;
+	}
+	return config.multi_snoop_enabled && pcm->mode == BA_TRANSPORT_PCM_MODE_SOURCE;
+}
+
+/**
+ * The current delay due to buffering within the multi.
+ *
+ * The BlueALSA API can return only a single value to all clients for each PCM,
+ * so the value reported here is necessarily only an estimate, based on the
+ * number of unread frames in the mix buffer plus a constant value
+ * approximating the "typical" number of frames held in a client read buffer. */
+int ba_pcm_multi_delay_get(const struct ba_pcm_multi *multi) {
+	if (!ba_pcm_multi_is_sink(multi) || !multi->period_frames)
+		return 0;
+	int delay = ((ba_pcm_mix_buffer_delay(&multi->playback_buffer, multi->playback_buffer.end) / multi->pcm->channels)  + (BA_MULTI_CLIENT_THRESHOLD * multi->period_frames)) * 100 / multi->pcm->rate;
+	return delay;
+}
+
+/**
+ * Create multi-client support for the given transport pcm. */
+struct ba_pcm_multi *ba_pcm_multi_create(struct ba_transport_pcm *pcm) {
+
+	struct ba_pcm_multi *multi = calloc(1, sizeof(struct ba_pcm_multi));
+	if (multi == NULL)
+		return multi;
+
+	multi->pcm = pcm;
+	multi->thread = config.main_thread;
+
+	pthread_mutex_init(&multi->client_mutex, NULL);
+	pthread_mutex_init(&multi->buffer_mutex, NULL);
+	pthread_cond_init(&multi->cond, NULL);
+
+	if ((multi->epoll_fd = epoll_create(1)) == -1)
+		goto fail;
+
+	if ((multi->event_fd = eventfd(0, 0)) == -1)
+		goto fail;
+
+	return multi;
+
+fail:
+	if (multi->epoll_fd != -1)
+		close(multi->epoll_fd);
+	if (multi->event_fd != -1)
+		close(multi->event_fd);
+	free(multi);
+	return NULL;
+}
+
+/**
+ * Initialize multi-client support.
+ *
+ * Enable client audio I/O.
+ *
+ * @param multi The multi-client instance to be initialized.
+ * @return true if multi-client successfully initialized. */
+bool ba_pcm_multi_init(struct ba_pcm_multi *multi) {
+	debug("Initializing multi client support");
+
+	multi->state = BA_PCM_MULTI_STATE_INIT;
+	multi->period_frames = BA_MULTI_PERIOD_MS * multi->pcm->rate / 1000;
+	multi->period_bytes = multi->period_frames * multi->pcm->channels * BA_TRANSPORT_PCM_FORMAT_BYTES(multi->pcm->format);
+
+	if (ba_pcm_multi_is_sink(multi)) {
+		size_t buffer_frames = BA_MULTI_BUFFER_PERIODS * multi->period_frames;
+		if (ba_pcm_mix_buffer_init(&multi->playback_buffer,
+				multi->pcm->format, multi->pcm->channels,
+				buffer_frames, multi->period_frames) == -1)
+			return false;
+		multi->buffer_ready = false;
+		multi->active_count = 0;
+	}
+
+	multi->drain = false;
+	multi->drop = false;
+
+	ba_pcm_multi_init_clients(multi);
+
+	if (ba_pcm_multi_is_source(multi) && multi->client_count > 0) {
+		if (multi->thread == config.main_thread && !ba_pcm_multi_start(multi))
+			return false;
+	}
+	return true;
+}
+
+/**
+ * Stop the multi-client support. */
+void ba_pcm_multi_reset(struct ba_pcm_multi *multi) {
+	if (!ba_pcm_multi_is_target(multi))
+		ba_pcm_multi_cleanup(multi);
+	multi->state = BA_PCM_MULTI_STATE_INIT;
+}
+
+/**
+ * Release the resources used by a multi. */
+void ba_pcm_multi_free(struct ba_pcm_multi *multi) {
+	ba_pcm_multi_cleanup(multi);
+	g_list_free(multi->clients);
+
+	close(multi->epoll_fd);
+	close(multi->event_fd);
+
+	pthread_mutex_destroy(&multi->client_mutex);
+	pthread_mutex_destroy(&multi->buffer_mutex);
+	pthread_cond_destroy(&multi->cond);
+
+	free(multi);
+}
+
+/**
+ * Include a new client stream.
+ *
+ * Starts the multi thread if not already running.
+ *
+ * @param multi The multi to which the client is to be added.
+ * @param pcm_fd File descriptor for client audio i/o.
+ * @param control_fd File descriptor for client control commands.
+ * @return true if successful.
+ */
+bool ba_pcm_multi_add_client(struct ba_pcm_multi *multi, int pcm_fd, int control_fd) {
+	int rv = 0;
+	bool close_fd_on_fail = false;
+
+	if (multi->client_count == BA_MULTI_MAX_CLIENTS)
+		return false;
+
+	if (ba_pcm_multi_is_source(multi) && multi->state == BA_PCM_MULTI_STATE_FINISHED) {
+		/* client thread has failed - clean it up before starting new one. */
+		ba_pcm_multi_reset(multi);
+	}
+
+	pthread_mutex_lock(&multi->pcm->mutex);
+	if (multi->pcm->fd == -1) {
+		rv = multi->pcm->fd = eventfd(0, EFD_NONBLOCK);
+		close_fd_on_fail = true;
+	}
+	pthread_mutex_unlock(&multi->pcm->mutex);
+	if (rv == -1)
+		return false;
+
+	struct ba_pcm_client *client = ba_pcm_client_new(multi, pcm_fd, control_fd);
+	if (!client)
+		goto fail;
+
+	/* Postpone initialization of client if multi itself is not yet
+	 * initialized. */
+	if (multi->period_bytes > 0) {
+		if (!ba_pcm_client_init(client)) {
+			ba_pcm_client_free(client);
+			goto fail;
+		}
+	}
+
+#if DEBUG
+	client->id = ++multi->client_no;
+#endif
+
+	pthread_mutex_lock(&multi->client_mutex);
+
+	multi->clients = g_list_prepend(multi->clients, client);
+	multi->client_count++;
+
+	if (ba_pcm_multi_is_sink(multi)) {
+		if (multi->state == BA_PCM_MULTI_STATE_FINISHED)
+			multi->state = BA_PCM_MULTI_STATE_INIT;
+	}
+	else {
+		if (multi->state == BA_PCM_MULTI_STATE_INIT)
+			multi->state = BA_PCM_MULTI_STATE_RUNNING;
+	}
+
+	if (multi->thread == config.main_thread)
+		ba_pcm_multi_start(multi);
+
+	pthread_mutex_unlock(&multi->client_mutex);
+
+	if (multi->thread == config.main_thread)
+		goto fail;
+
+	if (multi->client_count == 1)
+		/* notify our PCM IO thread that the PCM was opened */
+		ba_transport_pcm_signal_send(multi->pcm, BA_TRANSPORT_PCM_SIGNAL_OPEN);
+
+	debug("new client id %zu, total clients now %zu", client->id, multi->client_count);
+	return true;
+
+fail:
+	if (close_fd_on_fail) {
+		pthread_mutex_lock(&multi->pcm->mutex);
+		if (multi->pcm->fd != -1) {
+			close(multi->pcm->fd);
+			multi->pcm->fd = -1;
+		}
+		pthread_mutex_unlock(&multi->pcm->mutex);
+	}
+	return false;
+}
+
+/**
+ * Remove a client stream.
+ * @return false if no clients remain, true otherwise. */
+static void ba_pcm_multi_remove_client(struct ba_pcm_multi *multi, struct ba_pcm_client *client) {
+	client->multi->clients = g_list_remove(multi->clients, client);
+	--client->multi->client_count;
+	debug("removed client no %zu, total clients now %zu", client->id, multi->client_count);
+	ba_pcm_client_free(client);
+}
+
+/**
+ * Write out decoded samples to the clients.
+ *
+ * Called by the transport I/O thread.
+ * @param multi Pointer to the multi.
+ * @param buffer Pointer to the buffer from which to obtain the samples.
+ * @param samples the number of samples available in the decoder buffer.
+ * @return the number of samples written. */
+ssize_t ba_pcm_multi_write(struct ba_pcm_multi *multi, const void *buffer, size_t samples) {
+
+	pthread_mutex_lock(&multi->client_mutex);
+
+	if (multi->state == BA_PCM_MULTI_STATE_FINISHED) {
+		pthread_mutex_lock(&multi->pcm->mutex);
+		ba_transport_pcm_release(multi->pcm);
+		pthread_mutex_unlock(&multi->pcm->mutex);
+		samples = 0;
+		goto finish;
+	}
+
+	GList *el;
+	for (el = multi->clients; el != NULL; el = el->next) {
+		struct ba_pcm_client *client = el->data;
+		enum ba_pcm_client_state client_state;
+		pthread_mutex_lock(&client->mutex);
+		client_state = client->state;
+		pthread_mutex_unlock(&client->mutex);
+		if (client_state == BA_PCM_CLIENT_STATE_RUNNING) {
+			ba_pcm_client_write(client, buffer, samples);
+			pthread_mutex_lock(&client->mutex);
+			client_state = client->state;
+			pthread_mutex_unlock(&client->mutex);
+		}
+		if (client_state == BA_PCM_CLIENT_STATE_FINISHED) {
+			ba_pcm_multi_remove_client(multi, client);
+		}
+	}
+
+finish:
+	pthread_mutex_unlock(&multi->client_mutex);
+	return (ssize_t) samples;
+}
+
+/**
+ * Read mixed samples.
+ *
+ * multi client replacement for io_pcm_read() */
+ssize_t ba_pcm_multi_read(struct ba_pcm_multi *multi, void *buffer, size_t samples) {
+	eventfd_t value = 0;
+	ssize_t ret;
+	enum ba_pcm_multi_state state;
+
+	pthread_mutex_lock(&multi->pcm->mutex);
+	if (multi->pcm->fd == -1) {
+		pthread_mutex_unlock(&multi->pcm->mutex);
+		errno = EBADF;
+		return -1;
+	}
+
+	/* Clear pcm available event */
+	ret = eventfd_read(multi->pcm->fd, &value);
+	pthread_mutex_unlock(&multi->pcm->mutex);
+	if (ret < 0 && errno != EAGAIN)
+		return ret;
+
+	/* Trigger client thread to re-fill the mix. */
+	pthread_mutex_lock(&multi->buffer_mutex);
+	eventfd_write(multi->event_fd, 1);
+
+	/* Wait for mix update to complete */
+	while (((state = multi->state) == BA_PCM_MULTI_STATE_RUNNING) && !multi->buffer_ready)
+		pthread_cond_wait(&multi->cond, &multi->buffer_mutex);
+	multi->buffer_ready = false;
+	pthread_mutex_unlock(&multi->buffer_mutex);
+
+	switch (state) {
+	case BA_PCM_MULTI_STATE_RUNNING:
+	{
+		double scale_array[multi->pcm->channels];
+		if (multi->pcm->soft_volume) {
+			for (unsigned i = 0; i < multi->pcm->channels; ++i)
+				scale_array[i] = multi->pcm->volume[i].scale;
+		}
+		else {
+			for (unsigned i = 0; i < multi->pcm->channels; ++i)
+				/* For pass-through volume control, we silence the samples if
+				 * mute is enabled, otherwise we apply the configured mix
+				 * attenuation. */
+				if (multi->pcm->volume[i].scale == 0)
+					scale_array[i] = 0;
+				else
+					scale_array[i] = config.multi_native_volume;
+		}
+		pthread_mutex_lock(&multi->buffer_mutex);
+		ret = ba_pcm_mix_buffer_read(&multi->playback_buffer, buffer, samples, scale_array);
+		pthread_mutex_unlock(&multi->buffer_mutex);
+		if (ret == 0) {
+			/* The mix buffer is empty. Any clients still running must have
+			 * underrun. */
+			ba_pcm_multi_underrun(multi);
+			errno = EAGAIN;
+			ret = -1;
+		}
+		break;
+	}
+	case BA_PCM_MULTI_STATE_FINISHED:
+		pthread_mutex_lock(&multi->pcm->mutex);
+		ba_transport_pcm_release(multi->pcm);
+		pthread_mutex_unlock(&multi->pcm->mutex);
+		ret = 0;
+		break;
+	case BA_PCM_MULTI_STATE_INIT:
+		errno = EAGAIN;
+		ret = -1;
+		break;
+	default:
+		errno = EIO;
+		ret = -1;
+		break;
+	}
+
+	return ret;
+}
+
+/**
+ * Signal the transport i/o thread that mixed samples are available. */
+static void ba_pcm_multi_wake_transport(struct ba_pcm_multi *multi) {
+	pthread_mutex_lock(&multi->pcm->mutex);
+	eventfd_write(multi->pcm->fd, 1);
+	pthread_mutex_unlock(&multi->pcm->mutex);
+}
+
+/**
+ * Add more samples from clients into the mix.
+ * Caller must hold lock on multi client_mutex  */
+static void ba_pcm_multi_update_mix(struct ba_pcm_multi *multi) {
+	GList *el;
+	for (el = multi->clients; el != NULL; el = el->next) {
+		struct ba_pcm_client *client = el->data;
+		ba_pcm_client_deliver(client);
+	}
+}
+
+/**
+ * Inform the io thread that the last client has closed its connection. */
+static void ba_pcm_multi_close(struct ba_pcm_multi *multi) {
+	pthread_mutex_lock(&multi->pcm->mutex);
+	ba_transport_pcm_release(multi->pcm);
+	pthread_mutex_unlock(&multi->pcm->mutex);
+	ba_transport_pcm_signal_send(multi->pcm, BA_TRANSPORT_PCM_SIGNAL_CLOSE);
+}
+
+/**
+ * The mix thread. */
+static void *ba_pcm_mix_thread_func(struct ba_pcm_multi *multi) {
+
+	struct epoll_event events[BA_MULTI_MAX_EVENTS] = { 0 };
+
+	struct epoll_event event = {
+		.events =  EPOLLIN,
+		.data.ptr = multi,
+	};
+
+	epoll_ctl(multi->epoll_fd, EPOLL_CTL_ADD, multi->event_fd, &event);
+
+	debug("Starting pcm mix loop");
+	for (;;) {
+
+		int event_count;
+		do {
+			event_count = epoll_wait(multi->epoll_fd, events, BA_MULTI_MAX_EVENTS, -1);
+		} while (event_count == -1 && errno == EINTR);
+
+		if (event_count <= 0) {
+			error("epoll_wait failed: %d (%s)", errno, strerror(errno));
+			goto terminate;
+		}
+
+		for (int n = 0; n < event_count; n++) {
+
+			if (events[n].data.ptr == multi) {
+				/* trigger from encoder thread */
+				eventfd_t value = 0;
+				eventfd_read(multi->event_fd, &value);
+				if (value >= 0xDEAD0000)
+					goto terminate;
+				pthread_mutex_lock(&multi->buffer_mutex);
+				pthread_mutex_lock(&multi->client_mutex);
+				ba_pcm_multi_update_mix(multi);
+				pthread_mutex_unlock(&multi->client_mutex);
+				multi->buffer_ready = true;
+				pthread_mutex_unlock(&multi->buffer_mutex);
+				pthread_cond_signal(&multi->cond);
+				break;
+			}
+
+			else {   /* client event */
+				struct ba_pcm_client_event *cevent = events[n].data.ptr;
+				struct ba_pcm_client *client = cevent->client;
+
+				ba_pcm_client_handle_event(cevent);
+
+				if (client->state == BA_PCM_CLIENT_STATE_FINISHED) {
+					pthread_mutex_lock(&multi->client_mutex);
+					ba_pcm_multi_remove_client(multi, client);
+					pthread_mutex_unlock(&multi->client_mutex);
+
+					/* removing a client invalidates the event array, so
+					 * we need to call epoll_wait() again here */
+					break;
+				}
+			}
+		}
+
+		if (multi->client_count == 0) {
+			multi->state = BA_PCM_MULTI_STATE_FINISHED;
+			pthread_mutex_lock(&multi->buffer_mutex);
+			ba_pcm_mix_buffer_clear(&multi->playback_buffer);
+			pthread_mutex_unlock(&multi->buffer_mutex);
+			ba_pcm_multi_close(multi);
+			continue;
+		}
+
+		if (multi->client_count == 1) {
+			struct ba_pcm_client* client = g_list_first(multi->clients)->data;
+			if (client->drop) {
+				pthread_mutex_lock(&multi->pcm->mutex);
+				pthread_mutex_lock(&multi->buffer_mutex);
+				ba_pcm_mix_buffer_clear(&multi->playback_buffer);
+				pthread_mutex_unlock(&multi->buffer_mutex);
+				/* Clear any remaining pcm available event */
+				if (multi->pcm->fd != -1) {
+					eventfd_t value;
+					eventfd_read(multi->pcm->fd, &value);
+				}
+				pthread_mutex_unlock(&multi->pcm->mutex);
+				ba_transport_pcm_drop(multi->pcm);
+				client->drop = false;
+				multi->state = BA_PCM_MULTI_STATE_INIT;
+				continue;
+			}
+		}
+
+		if (multi->state == BA_PCM_MULTI_STATE_INIT) {
+			if (multi->active_count > 0) {
+				pthread_mutex_lock(&multi->buffer_mutex);
+				pthread_mutex_lock(&multi->client_mutex);
+				ba_pcm_multi_update_mix(multi);
+				pthread_mutex_unlock(&multi->client_mutex);
+				if (ba_pcm_mix_buffer_at_threshold(&multi->playback_buffer)) {
+					multi->state = BA_PCM_MULTI_STATE_RUNNING;
+					ba_transport_pcm_resume(multi->pcm);
+				}
+				pthread_mutex_unlock(&multi->buffer_mutex);
+			}
+		}
+		else if (multi->state == BA_PCM_MULTI_STATE_RUNNING) {
+			if (ba_pcm_mix_buffer_empty(&multi->playback_buffer))
+				multi->state = BA_PCM_MULTI_STATE_INIT;
+			else
+				ba_pcm_multi_wake_transport(multi);
+		}
+	}
+
+terminate:
+	multi->state = BA_PCM_MULTI_STATE_FINISHED;
+	pthread_cond_signal(&multi->cond);
+	ba_pcm_multi_wake_transport(multi);
+	debug("mix thread function terminated");
+	return NULL;
+}
+
+
+/**
+ * The snoop thread. */
+static void *ba_pcm_snoop_thread_func(struct ba_pcm_multi *multi) {
+
+	struct epoll_event events[BA_MULTI_MAX_EVENTS];
+
+	struct epoll_event event = {
+		.events =  EPOLLIN,
+		.data.ptr = multi,
+	};
+
+	epoll_ctl(multi->epoll_fd, EPOLL_CTL_ADD, multi->event_fd, &event);
+
+	debug("Starting pcm snoop loop");
+	for (;;) {
+		int ret;
+
+		do {
+			ret = epoll_wait(multi->epoll_fd, events, BA_MULTI_MAX_EVENTS, -1);
+		} while (ret == -1 && errno == EINTR);
+
+		if (ret <= 0) {
+			error("epoll_wait failed: %d (%s)", errno, strerror(errno));
+			goto terminate;
+		}
+
+		for (int n = 0; n < ret; n++) {
+
+			if (events[n].data.ptr == multi) {
+				/* trigger from transport thread */
+				eventfd_t value = 0;
+				eventfd_read(multi->event_fd, &value);
+				if (value >= 0xDEAD0000)
+					goto terminate;
+
+			}
+
+			else {
+				/* client event */
+				struct ba_pcm_client_event *cevent = events[n].data.ptr;
+				if (events[n].events & (EPOLLHUP|EPOLLERR)) {
+					ba_pcm_client_handle_close_event(cevent);
+					pthread_mutex_lock(&multi->client_mutex);
+					ba_pcm_multi_remove_client(multi, cevent->client);
+					pthread_mutex_unlock(&multi->client_mutex);
+					if (multi->client_count == 0) {
+						multi->state = BA_PCM_MULTI_STATE_FINISHED;
+						ba_pcm_multi_close(multi);
+					}
+
+					/* removing a client invalidates the event array, so
+					 * we need to call epoll_wait() again here */
+					break;
+				}
+				else {
+					ba_pcm_client_handle_event(cevent);
+					if (multi->state == BA_PCM_MULTI_STATE_PAUSED && multi->active_count > 0) {
+						multi->state = BA_PCM_MULTI_STATE_RUNNING;
+						ba_transport_pcm_resume(multi->pcm);
+;
+					}
+				}
+			}
+		}
+	}
+
+terminate:
+	multi->state = BA_PCM_MULTI_STATE_FINISHED;
+	debug("snoop thread function terminated");
+	return NULL;
+}

--- a/src/ba-pcm-multi.h
+++ b/src/ba-pcm-multi.h
@@ -1,0 +1,96 @@
+/*
+ * BlueALSA - ba-pcm-multi.h
+ * SPDX-FileCopyrightText: 2016-2025 BlueALSA developers
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+#ifndef BLUEALSA_BAPCMMULTI_H_
+#define BLUEALSA_BAPCMMULTI_H_
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <glib.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "ba-pcm-mix-buffer.h"
+
+/* Number of periods to hold in mix before starting playback. */
+#define BA_MULTI_MIX_THRESHOLD 4
+
+/* Number of periods to hold in client before starting mix. */
+#define BA_MULTI_CLIENT_THRESHOLD 2
+
+
+struct ba_transport;
+struct ba_transport_pcm;
+
+enum ba_pcm_multi_state {
+	BA_PCM_MULTI_STATE_INIT = 0,
+	BA_PCM_MULTI_STATE_RUNNING,
+	BA_PCM_MULTI_STATE_PAUSED,
+	BA_PCM_MULTI_STATE_FINISHED,
+};
+
+struct ba_snoop_buffer {
+	const uint8_t *data;
+	size_t len;
+};
+
+struct ba_pcm_multi {
+	struct ba_transport_pcm *pcm;
+	union {
+		struct ba_mix_buffer playback_buffer;
+		struct ba_snoop_buffer capture_buffer;
+	};
+	size_t period_bytes;
+	size_t period_frames;
+	GList *clients;
+	/* The number of clients currently connected to this multi */
+	size_t client_count;
+	/* The number of clients actively transferring audio */
+	size_t active_count;
+	_Atomic enum ba_pcm_multi_state state;
+	int epoll_fd;
+	int event_fd;
+	pthread_t thread;
+	/* Controls access to the clients list */
+	pthread_mutex_t client_mutex;
+	/* Controls access to the playback mix buffer */
+	pthread_mutex_t buffer_mutex;
+	/* Synchronize playback buffer updates */
+	pthread_cond_t cond;
+	bool buffer_ready;
+	bool drain;
+	bool drop;
+#if DEBUG
+	size_t client_no;
+#endif
+};
+
+bool ba_pcm_multi_enabled(const struct ba_transport_pcm *pcm);
+
+struct ba_pcm_multi *ba_pcm_multi_create(struct ba_transport_pcm *pcm);
+
+bool ba_pcm_multi_init(struct ba_pcm_multi *multi);
+
+void ba_pcm_multi_reset(struct ba_pcm_multi *multi);
+
+void ba_pcm_multi_free(struct ba_pcm_multi *multi);
+
+bool ba_pcm_multi_add_client(struct ba_pcm_multi *multi, int pcm_fd, int control_fd);
+
+ssize_t ba_pcm_multi_read(struct ba_pcm_multi *multi, void *buffer, size_t samples);
+
+ssize_t ba_pcm_multi_write(struct ba_pcm_multi *multi, const void *buffer, size_t samples);
+
+ssize_t ba_pcm_multi_fetch(struct ba_pcm_multi *multi, void *buffer, size_t samples, bool *restarted);
+
+int ba_pcm_multi_delay_get(const struct ba_pcm_multi *multi);
+
+#endif

--- a/src/ba-transport-pcm.c
+++ b/src/ba-transport-pcm.c
@@ -28,6 +28,7 @@
 #include "audio.h"
 #include "ba-config.h"
 #include "ba-device.h"
+#include "ba-pcm-multi.h"
 #include "ba-rfcomm.h"
 #include "ba-transport.h"
 #include "bluealsa-dbus.h"
@@ -83,6 +84,9 @@ int transport_pcm_init(
 	pcm->pipe[0] = -1;
 	pcm->pipe[1] = -1;
 
+	pcm->multi = NULL;
+	pcm->paused = false;
+
 	for (size_t i = 0; i < ARRAYSIZE(pcm->volume); i++) {
 		pcm->volume[i].level = config.volume_init_level;
 		ba_transport_pcm_volume_set(&pcm->volume[i], NULL, NULL, NULL);
@@ -99,6 +103,9 @@ int transport_pcm_init(
 	pcm->ba_dbus_path = g_strdup_printf("%s/%s/%s",
 			t->d->ba_dbus_path, transport_get_dbus_path_type(t->profile),
 			mode == BA_TRANSPORT_PCM_MODE_SOURCE ? "source" : "sink");
+
+	if (ba_pcm_multi_enabled(pcm))
+		pcm->multi = ba_pcm_multi_create(pcm);
 
 	return 0;
 }
@@ -121,6 +128,11 @@ void transport_pcm_free(
 		close(pcm->pipe[1]);
 
 	g_free(pcm->ba_dbus_path);
+
+	if (pcm->multi != NULL) {
+		ba_pcm_multi_free(pcm->multi);
+		pcm->multi = NULL;
+	}
 
 }
 
@@ -242,6 +254,10 @@ void ba_transport_pcm_thread_cleanup(struct ba_transport_pcm *pcm) {
 	ba_transport_stop_async(t);
 	pthread_mutex_unlock(&t->bt_fd_mtx);
 
+	/* Stop multi client thread if required. */
+	if (pcm->multi)
+		ba_pcm_multi_reset(pcm->multi);
+
 	/* Release BT socket file descriptor duplicate created either in the
 	 * ba_transport_pcm_start() function or in the IO thread itself. */
 	ba_transport_pcm_bt_release(pcm);
@@ -352,6 +368,11 @@ int ba_transport_pcm_start(
 	if ((ret = pthread_sigmask(SIG_SETMASK, &sigset, &oldset)) != 0)
 		warn("Couldn't set signal mask: %s", strerror(ret));
 
+	/* Ensure that, if required, the multi-client support is initialised
+	 * before the PCM I/O thread is started. */
+	if (pcm->multi)
+		ba_pcm_multi_init(pcm->multi);
+
 	if ((ret = pthread_create(&pcm->tid, NULL, PTHREAD_FUNC(th_func), pcm)) != 0) {
 		error("Couldn't create IO thread: %s", strerror(ret));
 		pcm->state = BA_TRANSPORT_PCM_STATE_TERMINATED;
@@ -374,6 +395,8 @@ int ba_transport_pcm_start(
 	debug("Created new IO thread [%s]: %s", name, ba_transport_debug_name(t));
 
 fail:
+	if (pcm->multi && ret != 0)
+		ba_pcm_multi_reset(pcm->multi);
 	pthread_mutex_unlock(&pcm->state_mtx);
 	pthread_cond_broadcast(&pcm->cond);
 	return ret == 0 ? 0 : -1;
@@ -751,7 +774,10 @@ int ba_transport_pcm_delay_get(
 	else if (t->profile & BA_TRANSPORT_PROFILE_MASK_AG)
 		delay += 10;
 
-	return delay;
+	if (pcm->multi)
+		return delay + ba_pcm_multi_delay_get(pcm->multi);
+	else
+		return delay;
 }
 
 /**

--- a/src/ba-transport-pcm.h
+++ b/src/ba-transport-pcm.h
@@ -159,6 +159,9 @@ struct ba_transport_pcm {
 	char *ba_dbus_path;
 	bool ba_dbus_exported;
 
+	/* Multi-client stream support */
+	struct ba_pcm_multi *multi;
+
 };
 
 int transport_pcm_init(

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -33,6 +33,7 @@
 #include "ba-adapter.h"
 #include "ba-config.h"
 #include "ba-device.h"
+#include "ba-pcm-multi.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
 #include "bluealsa-iface.h"
@@ -520,7 +521,7 @@ static void bluealsa_pcm_open(GDBusMethodInvocation *inv, void *userdata) {
 	const int pcm_fd = pcm->fd;
 	pthread_mutex_unlock(&pcm->mutex);
 
-	if (pcm_fd != -1) {
+	if (pcm->multi == NULL && pcm_fd != -1) {
 		g_dbus_method_invocation_return_error(inv, G_DBUS_ERROR,
 				G_DBUS_ERROR_LIMITS_EXCEEDED, "%s", strerror(EBUSY));
 		goto fail;
@@ -546,7 +547,7 @@ static void bluealsa_pcm_open(GDBusMethodInvocation *inv, void *userdata) {
 	 * headset will not run voltage converter (power-on its circuit board) until
 	 * the transport is acquired in order to extend battery life. For profiles
 	 * like A2DP Sink and HFP headset, we will wait for incoming connection. */
-	if (t_profile & (
+	if (pcm_fd == -1 && t_profile & (
 				BA_TRANSPORT_PROFILE_A2DP_SOURCE |
 #if ENABLE_ASHA
 				BA_TRANSPORT_PROFILE_ASHA_SOURCE |
@@ -568,23 +569,34 @@ static void bluealsa_pcm_open(GDBusMethodInvocation *inv, void *userdata) {
 
 	}
 
-	pthread_mutex_lock(&pcm->mutex);
+	/* When multiple client support is enabled, management is delegated to the
+	 * multi client thread.
+	 * Otherwise control channels are managed in this thread. */
+	if (pcm->multi) {
+		/* create new multi client instance */
+		if (!ba_pcm_multi_add_client(pcm->multi, pcm_fds[is_sink ? 0 : 1], pcm_fds[2]))
+			goto fail;
+	}
+	else {
+		pthread_mutex_lock(&pcm->mutex);
 
-	/* get correct PIPE endpoint - PIPE is unidirectional */
-	pcm->fd = pcm_fds[is_sink ? 0 : 1];
-	/* set newly opened PCM as active */
-	pcm->paused = false;
+		/* get correct PIPE endpoint - PIPE is unidirectional */
+		pcm->fd = pcm_fds[is_sink ? 0 : 1];
+		/* set newly opened PCM as active */
+		pcm->paused = false;
 
-	GIOChannel * ch = g_io_channel_unix_raw_new(pcm_fds[2]);
-	pcm->controller = g_io_create_watch_full(ch, G_PRIORITY_DEFAULT,
-			G_IO_IN, bluealsa_pcm_controller, ba_transport_pcm_ref(pcm),
-			(GDestroyNotify)ba_transport_pcm_unref);
-	g_io_channel_unref(ch);
+		GIOChannel * ch = g_io_channel_unix_raw_new(pcm_fds[2]);
+		pcm->controller = g_io_create_watch_full(ch, G_PRIORITY_DEFAULT,
+				G_IO_IN, bluealsa_pcm_controller, ba_transport_pcm_ref(pcm),
+				(GDestroyNotify)ba_transport_pcm_unref);
+		g_io_channel_unref(ch);
 
-	pthread_mutex_unlock(&pcm->mutex);
+		pthread_mutex_unlock(&pcm->mutex);
 
-	/* notify our PCM IO thread that the PCM was opened */
-	ba_transport_pcm_signal_send(pcm, BA_TRANSPORT_PCM_SIGNAL_OPEN);
+		/* notify our PCM IO thread that the PCM was opened */
+		ba_transport_pcm_signal_send(pcm, BA_TRANSPORT_PCM_SIGNAL_OPEN);
+
+	}
 
 	int fds[2] = { pcm_fds[is_sink ? 1 : 0], pcm_fds[3] };
 	GUnixFDList *fd_list = g_unix_fd_list_new_from_array(fds, 2);

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -32,6 +32,7 @@
 #include "ba-adapter.h"
 #include "ba-config.h"
 #include "ba-device.h"
+#include "ba-pcm-multi.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
 #include "bluealsa-iface.h"
@@ -519,7 +520,7 @@ static void bluealsa_pcm_open(GDBusMethodInvocation *inv, void *userdata) {
 	const int pcm_fd = pcm->fd;
 	pthread_mutex_unlock(&pcm->mutex);
 
-	if (pcm_fd != -1) {
+	if (pcm->multi == NULL && pcm_fd != -1) {
 		g_dbus_method_invocation_return_error(inv, G_DBUS_ERROR,
 				G_DBUS_ERROR_LIMITS_EXCEEDED, "%s", strerror(EBUSY));
 		goto fail;
@@ -545,7 +546,7 @@ static void bluealsa_pcm_open(GDBusMethodInvocation *inv, void *userdata) {
 	 * headset will not run voltage converter (power-on its circuit board) until
 	 * the transport is acquired in order to extend battery life. For profiles
 	 * like A2DP Sink and HFP headset, we will wait for incoming connection. */
-	if (t_profile & (
+	if (pcm_fd == -1 && t_profile & (
 				BA_TRANSPORT_PROFILE_A2DP_SOURCE |
 #if ENABLE_ASHA
 				BA_TRANSPORT_PROFILE_ASHA_SOURCE |
@@ -567,23 +568,34 @@ static void bluealsa_pcm_open(GDBusMethodInvocation *inv, void *userdata) {
 
 	}
 
-	pthread_mutex_lock(&pcm->mutex);
+	/* When multiple client support is enabled, management is delegated to the
+	 * multi client thread.
+	 * Otherwise control channels are managed in this thread. */
+	if (pcm->multi) {
+		/* create new multi client instance */
+		if (!ba_pcm_multi_add_client(pcm->multi, pcm_fds[is_sink ? 0 : 1], pcm_fds[2]))
+			goto fail;
+	}
+	else {
+		pthread_mutex_lock(&pcm->mutex);
 
-	/* get correct PIPE endpoint - PIPE is unidirectional */
-	pcm->fd = pcm_fds[is_sink ? 0 : 1];
-	/* set newly opened PCM as active */
-	pcm->paused = false;
+		/* get correct PIPE endpoint - PIPE is unidirectional */
+		pcm->fd = pcm_fds[is_sink ? 0 : 1];
+		/* set newly opened PCM as active */
+		pcm->paused = false;
 
-	GIOChannel * ch = g_io_channel_unix_raw_new(pcm_fds[2]);
-	pcm->controller = g_io_create_watch_full(ch, G_PRIORITY_DEFAULT,
-			G_IO_IN, bluealsa_pcm_controller, ba_transport_pcm_ref(pcm),
-			(GDestroyNotify)ba_transport_pcm_unref);
-	g_io_channel_unref(ch);
+		GIOChannel * ch = g_io_channel_unix_raw_new(pcm_fds[2]);
+		pcm->controller = g_io_create_watch_full(ch, G_PRIORITY_DEFAULT,
+				G_IO_IN, bluealsa_pcm_controller, ba_transport_pcm_ref(pcm),
+				(GDestroyNotify)ba_transport_pcm_unref);
+		g_io_channel_unref(ch);
 
-	pthread_mutex_unlock(&pcm->mutex);
+		pthread_mutex_unlock(&pcm->mutex);
 
-	/* notify our PCM IO thread that the PCM was opened */
-	ba_transport_pcm_signal_send(pcm, BA_TRANSPORT_PCM_SIGNAL_OPEN);
+		/* notify our PCM IO thread that the PCM was opened */
+		ba_transport_pcm_signal_send(pcm, BA_TRANSPORT_PCM_SIGNAL_OPEN);
+
+	}
 
 	int fds[2] = { pcm_fds[is_sink ? 1 : 0], pcm_fds[3] };
 	GUnixFDList *fd_list = g_unix_fd_list_new_from_array(fds, 2);

--- a/src/io.c
+++ b/src/io.c
@@ -19,6 +19,7 @@
 
 #include "audio.h"
 #include "ba-config.h"
+#include "ba-pcm-multi.h"
 #include "shared/defs.h"
 #include "shared/ffb.h"
 #include "shared/log.h"
@@ -177,7 +178,7 @@ ssize_t io_pcm_flush(struct ba_transport_pcm *pcm) {
 
 /**
  * Read PCM signal from the transport PCM FIFO. */
-ssize_t io_pcm_read(
+ssize_t io_pcm_single_read(
 		struct ba_transport_pcm *pcm,
 		void *buffer,
 		size_t samples) {
@@ -208,8 +209,23 @@ ssize_t io_pcm_read(
 }
 
 /**
- * Write PCM signal to the transport PCM FIFO. */
-ssize_t io_pcm_write(
+ * Read PCM signal from the transport PCM FIFO or mix as appropriate. */
+ssize_t io_pcm_read(
+		struct ba_transport_pcm *pcm,
+		void *buffer,
+		size_t samples) {
+	if (pcm->multi)
+		return ba_pcm_multi_read(pcm->multi, buffer, samples);
+	else
+		return io_pcm_single_read(pcm, buffer, samples);
+}
+
+/**
+ * Write PCM signal to the transport PCM FIFO.
+ *
+ * Note:
+ * This function may temporally re-enable thread cancellation! */
+ssize_t io_pcm_single_write(
 		struct ba_transport_pcm *pcm,
 		const void *buffer,
 		size_t samples) {
@@ -273,6 +289,21 @@ static void io_poll_drain_complete(
 	io->draining = false;
 	io->timeout = -1;
 
+}
+
+/**
+ * Write samples to PCM.
+ *
+ * Selects either multi or direct client FIFO depending on whether
+ * multi client support is enabled. */
+ssize_t io_pcm_write(
+		struct ba_transport_pcm *pcm,
+		const void *buffer,
+		size_t samples) {
+	if (pcm->multi == NULL)
+		return io_pcm_single_write(pcm, buffer, samples);
+	else
+		return ba_pcm_multi_write(pcm->multi, buffer, samples);
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -167,7 +167,7 @@ static void g_bus_name_lost(G_GNUC_UNUSED GDBusConnection * conn,
 int main(int argc, char **argv) {
 
 	int opt;
-	static const char * opts = "hVSB:i:p:c:";
+	static const char * opts = "hVSB:Mi:p:c:";
 	static const struct option longopts[] = {
 		{ "help", no_argument, NULL, 'h' },
 		{ "version", no_argument, NULL, 'V' },
@@ -175,10 +175,12 @@ int main(int argc, char **argv) {
 		{ "loglevel", required_argument, NULL, 23 },
 		{ "dbus", required_argument, NULL, 'B' },
 		{ "device", required_argument, NULL, 'i' },
+		{ "multi-client", optional_argument, NULL, 'M' },
 		{ "profile", required_argument, NULL, 'p' },
 		{ "codec", required_argument, NULL, 'c' },
 		{ "all-codecs", no_argument, NULL, 25 },
 		{ "initial-volume", required_argument, NULL, 17 },
+		{ "multi-attenuation", required_argument, NULL, 26 },
 		{ "keep-alive", required_argument, NULL, 8 },
 		{ "io-rt-priority", required_argument, NULL, 3 },
 		{ "disable-realtek-usb-fix", no_argument, NULL, 21 },
@@ -328,6 +330,8 @@ int main(int argc, char **argv) {
 					"      --loglevel=LEVEL\t\tset logging level; default: %s\n"
 					"  -B, --dbus=NAME\t\tprepend BlueALSA D-Bus service name suffix\n"
 					"  -i, --device=DEV\t\tHCI device to use given by name or MAC address\n"
+					"  -M, --multi-client[=DIRECTION]\tpermit multiple clients for each transport PCM\n"
+					"      --multi-attenuation=NUM\tattenuate mix pass-through volume [0-99]\n"
 					"  -p, --profile=NAME\t\tenable BT profile by NAME\n"
 					"  -c, --codec=[-]NAME\t\tenable/disable audio codec by NAME\n"
 					"      --all-codecs\t\tenable all supported audio codecs\n"
@@ -485,6 +489,33 @@ int main(int argc, char **argv) {
 			g_array_append_val(config.hci_filter, optarg);
 			break;
 
+		case 'M' /* --multi-client */ : {
+
+			if (optarg == NULL) {
+				config.multi_mix_enabled = true;
+				config.multi_snoop_enabled = true;
+			}
+			else {
+				static const nv_entry_t values[] = {
+					{ "output", .v.u = 0x1 },
+					{ "input", .v.u = 0x2 },
+					{ "both", .v.u = 0x3 },
+					{ 0 },
+				};
+
+				const nv_entry_t *entry;
+				if ((entry = nv_lookup_entry(values, optarg)) == NULL) {
+					error("Invalid multi-client direction {%s}: %s", nv_join_names(values), optarg);
+					return EXIT_FAILURE;
+				}
+				if (entry->v.u & 0x1)
+					config.multi_mix_enabled = true;
+				if (entry->v.u & 0x2)
+					config.multi_snoop_enabled = true;
+			}
+			break;
+		}
+
 		case 'p' /* --profile=NAME */ : {
 
 			static const struct {
@@ -587,6 +618,16 @@ int main(int argc, char **argv) {
 			}
 			double level = audio_loudness_to_decibel(1.0 * vol / 100);
 			config.volume_init_level = MIN(MAX(level, -96.0), 96.0) * 100;
+			break;
+		}
+
+		case 26 /* --multi-attenuation=NUM */ : {
+			unsigned int attenuation = atoi(optarg);
+			if (attenuation > 99) {
+				error("Invalid multi mix attenuation [0, 100]: %s", optarg);
+				return EXIT_FAILURE;
+			}
+			config.multi_native_volume = (double)(100 - attenuation) / 100;
 			break;
 		}
 

--- a/test/test-a2dp.c
+++ b/test/test-a2dp.c
@@ -13,7 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-
+#include <sys/types.h>
 #include <check.h>
 #include <glib.h>
 

--- a/test/test-io.c
+++ b/test/test-io.c
@@ -76,6 +76,7 @@
 #include "ba-adapter.h"
 #include "ba-config.h"
 #include "ba-device.h"
+#include "ba-pcm-multi.h"
 #include "ba-rfcomm.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
@@ -662,7 +663,7 @@ static void *test_io_thread_dump_pcm(struct ba_transport_pcm *t_pcm) {
 }
 
 /**
- * Drive PCM signal through source/sink loop. */
+ * Drive PCM signal through source/sink loop (single client mode). */
 static void test_io(
 		struct ba_transport_pcm *t_src_pcm, struct ba_transport_pcm *t_snk_pcm,
 		ba_transport_pcm_thread_func enc, ba_transport_pcm_thread_func dec,
@@ -727,6 +728,132 @@ static void test_io(
 
 	ba_transport_stop(t_snk);
 
+}
+
+/**
+ * Drive PCM signal through source/sink loop (multi client mix mode). */
+static void test_io_multi_mix(
+		struct ba_transport_pcm *t_src_pcm, struct ba_transport_pcm *t_snk_pcm,
+		ba_transport_pcm_thread_func enc, ba_transport_pcm_thread_func dec,
+		size_t pcm_write_frames_count) {
+
+	const char *enc_name = "encode";
+	const char *dec_name = "dump-bt";
+	struct ba_transport *t_src = t_src_pcm->t;
+	struct ba_transport *t_snk = t_snk_pcm->t;
+
+	if (input_bt_file != NULL)
+		return;
+
+	/* Reset the global termination flag before starting the loop. */
+	test_terminated = false;
+
+	int bt_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0, bt_fds), 0);
+	debug("Created BT socket pair: %d, %d", bt_fds[0], bt_fds[1]);
+
+	t_src->bt_fd = bt_fds[1];
+	t_snk->bt_fd = bt_fds[0];
+
+	int pcm_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, pcm_fds), 0);
+	debug("Created PCM socket pair: %d, %d", pcm_fds[0], pcm_fds[1]);
+	t_snk_pcm->fd = pcm_fds[0];
+
+	int ctl_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, ctl_fds), 0);
+
+	bt_data_init();
+
+	if (aging_duration)
+		test_start_terminate_timer(aging_duration);
+
+	ck_assert_ptr_nonnull(t_src_pcm->multi = ba_pcm_multi_create(t_src_pcm));
+	ck_assert_int_eq(ba_transport_pcm_start(t_src_pcm, enc, enc_name), 0);
+	ck_assert_int_eq(ba_transport_pcm_start(t_snk_pcm, dec, dec_name), 0);
+	ck_assert_int_eq(ba_pcm_multi_add_client(t_src_pcm->multi, pcm_fds[1], ctl_fds[1]), 1);
+	pcm_write_frames(t_snk_pcm, pcm_write_frames_count);
+
+	pthread_mutex_lock(&test_mutex);
+	while (!test_terminated)
+		pthread_cond_wait(&test_terminate, &test_mutex);
+	pthread_mutex_unlock(&test_mutex);
+
+	pthread_mutex_lock(&t_src_pcm->mutex);
+	ba_transport_pcm_release(t_src_pcm);
+	pthread_mutex_unlock(&t_src_pcm->mutex);
+
+	ba_transport_stop(t_src);
+
+	pthread_mutex_lock(&t_snk_pcm->mutex);
+	ba_transport_pcm_release(t_snk_pcm);
+	pthread_mutex_unlock(&t_snk_pcm->mutex);
+
+	ba_transport_stop(t_snk);
+	close(ctl_fds[0]);
+	close(ctl_fds[1]);
+}
+
+/**
+ * Drive PCM signal through source/sink loop (multi client snoop mode). */
+static void test_io_multi_snoop(
+		struct ba_transport_pcm *t_src_pcm, struct ba_transport_pcm *t_snk_pcm,
+		ba_transport_pcm_thread_func enc, ba_transport_pcm_thread_func dec) {
+
+	const char *enc_name = "dump-pcm";
+	const char *dec_name = "decode";
+	struct ba_transport *t_src = t_src_pcm->t;
+	struct ba_transport *t_snk = t_snk_pcm->t;
+
+	if (input_pcm_file != NULL)
+		return;
+
+	/* Reset the global termination flag before starting the loop. */
+	test_terminated = false;
+
+	int bt_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0, bt_fds), 0);
+	debug("Created BT socket pair: %d, %d", bt_fds[0], bt_fds[1]);
+	t_src->bt_fd = bt_fds[1];
+	t_snk->bt_fd = bt_fds[0];
+
+	int pcm_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, pcm_fds), 0);
+	debug("Created PCM socket pair: %d, %d", pcm_fds[0], pcm_fds[1]);
+	t_src_pcm->fd = pcm_fds[1];
+	t_snk_pcm->fd = pcm_fds[0];
+
+	int ctl_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, ctl_fds), 0);
+
+	if (aging_duration)
+		test_start_terminate_timer(aging_duration);
+
+	ck_assert_ptr_nonnull(t_snk_pcm->multi = ba_pcm_multi_create(t_snk_pcm));
+	ck_assert_int_eq(ba_pcm_multi_init(t_snk_pcm->multi), 1);
+	ck_assert_int_eq(ba_pcm_multi_add_client(t_snk_pcm->multi, pcm_fds[0], ctl_fds[0]), 1);
+	ck_assert_int_eq(ba_transport_pcm_start(t_snk_pcm, dec, dec_name), 0);
+	ck_assert_int_eq(ba_transport_pcm_start(t_src_pcm, enc, enc_name), 0);
+	bt_data_write(t_src);
+
+	pthread_mutex_lock(&test_mutex);
+	while (!test_terminated)
+		pthread_cond_wait(&test_terminate, &test_mutex);
+	pthread_mutex_unlock(&test_mutex);
+
+	pthread_mutex_lock(&t_src_pcm->mutex);
+	ba_transport_pcm_release(t_src_pcm);
+	pthread_mutex_unlock(&t_src_pcm->mutex);
+
+	ba_transport_stop(t_src);
+
+	pthread_mutex_lock(&t_snk_pcm->mutex);
+	ba_transport_pcm_release(t_snk_pcm);
+	pthread_mutex_unlock(&t_snk_pcm->mutex);
+
+	ba_transport_stop(t_snk);
+	close(ctl_fds[0]);
+	close(ctl_fds[1]);
 }
 
 static int test_transport_acquire(struct ba_transport *t) {
@@ -1043,6 +1170,33 @@ CK_START_TEST(test_a2dp_sbc_pcm_drop) {
 
 } CK_END_TEST
 
+CK_START_TEST(test_a2dp_sbc_multi) {
+
+	struct ba_transport *t1 = test_transport_new_a2dp(device1,
+			BA_TRANSPORT_PROFILE_A2DP_SOURCE, "/path/sbc", &a2dp_sbc_source,
+			&config_sbc_44100_stereo);
+	struct ba_transport *t2 = test_transport_new_a2dp(device2,
+			BA_TRANSPORT_PROFILE_A2DP_SINK, "/path/sbc", &a2dp_sbc_sink,
+			&config_sbc_44100_stereo);
+
+	struct ba_transport_pcm *t1_pcm = &t1->media.pcm;
+	struct ba_transport_pcm *t2_pcm = &t2->media.pcm;
+
+	if (aging_duration) {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 153 * 3;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_sbc_enc_thread, a2dp_sbc_dec_thread, 4 * 1024);
+	}
+	else {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 153 * 3;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_sbc_enc_thread, test_io_thread_dump_bt, 4 * 1024);
+		test_io_multi_snoop(t1_pcm, t2_pcm, test_io_thread_dump_pcm, a2dp_sbc_dec_thread);
+	}
+
+	ba_transport_destroy(t1);
+	ba_transport_destroy(t2);
+
+} CK_END_TEST
+
 #if ENABLE_MP3LAME
 CK_START_TEST(test_a2dp_mp3) {
 
@@ -1209,6 +1363,33 @@ CK_START_TEST(test_a2dp_aptx_hd) {
 		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 60;
 		test_io(t1_pcm, t2_pcm, a2dp_aptx_hd_enc_thread, test_io_thread_dump_bt, 2 * 1024);
 		test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, a2dp_aptx_hd_dec_thread, 2 * 1024);
+	};
+
+	ba_transport_destroy(t1);
+	ba_transport_destroy(t2);
+
+} CK_END_TEST
+
+CK_START_TEST(test_a2dp_aptx_hd_multi) {
+
+	struct ba_transport *t1 = test_transport_new_a2dp(device1,
+			BA_TRANSPORT_PROFILE_A2DP_SOURCE, "/path/aptxhd", &a2dp_aptx_hd_source,
+			&config_aptx_hd_44100_stereo);
+	struct ba_transport *t2 = test_transport_new_a2dp(device2,
+			BA_TRANSPORT_PROFILE_A2DP_SINK, "/path/aptxhd", &a2dp_aptx_hd_sink,
+			&config_aptx_hd_44100_stereo);
+
+	struct ba_transport_pcm *t1_pcm = &t1->media.pcm;
+	struct ba_transport_pcm *t2_pcm = &t2->media.pcm;
+
+	if (aging_duration) {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 600;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_aptx_hd_enc_thread, a2dp_aptx_hd_dec_thread, 4 * 1024);
+	}
+	else {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 60;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_aptx_hd_enc_thread, test_io_thread_dump_bt, 4 * 1024);
+		test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, a2dp_aptx_hd_dec_thread, 4 * 1024);
 	};
 
 	ba_transport_destroy(t1);
@@ -1466,8 +1647,8 @@ CK_START_TEST(test_sco_msbc) {
 	struct ba_transport_pcm *t2_pcm = &t2->sco.pcm_spk;
 
 	t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 24;
-	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 600);
-	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 600);
+	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 2 * 600);
+	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 2 * 600);
 
 	ba_transport_destroy(t1);
 	ba_transport_destroy(t2);
@@ -1492,8 +1673,8 @@ CK_START_TEST(test_sco_lc3_swb) {
 	struct ba_transport_pcm *t2_pcm = &t2->sco.pcm_spk;
 
 	t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 24;
-	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 600);
-	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 600);
+	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 2 * 600);
+	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 2 * 600);
 
 	ba_transport_destroy(t1);
 	ba_transport_destroy(t2);
@@ -1516,6 +1697,7 @@ int main(int argc, char *argv[]) {
 		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_pcm_drain },
 		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_pcm_drain_and_close },
 		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_pcm_drop },
+		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_multi },
 #if ENABLE_MP3LAME
 		{ a2dp_codec_to_string(A2DP_CODEC_MPEG12), test_a2dp_mp3 },
 #endif
@@ -1528,6 +1710,7 @@ int main(int argc, char *argv[]) {
 #endif
 #if ENABLE_APTX_HD_IO_TEST
 		{ a2dp_codec_to_string(A2DP_CODEC_VENDOR_ID(APTX_HD_VENDOR_ID, APTX_HD_CODEC_ID)), test_a2dp_aptx_hd },
+		{ a2dp_codec_to_string(A2DP_CODEC_VENDOR_ID(APTX_HD_VENDOR_ID, APTX_HD_CODEC_ID)), test_a2dp_aptx_hd_multi },
 #endif
 #if ENABLE_FASTSTREAM
 		{ a2dp_codec_to_string(A2DP_CODEC_VENDOR_ID(FASTSTREAM_VENDOR_ID, FASTSTREAM_CODEC_ID)), test_a2dp_faststream_music },

--- a/test/test-io.c
+++ b/test/test-io.c
@@ -73,6 +73,7 @@
 #include "ba-adapter.h"
 #include "ba-config.h"
 #include "ba-device.h"
+#include "ba-pcm-multi.h"
 #include "ba-rfcomm.h"
 #include "ba-transport.h"
 #include "ba-transport-pcm.h"
@@ -659,7 +660,7 @@ static void *test_io_thread_dump_pcm(struct ba_transport_pcm *t_pcm) {
 }
 
 /**
- * Drive PCM signal through source/sink loop. */
+ * Drive PCM signal through source/sink loop (single client mode). */
 static void test_io(
 		struct ba_transport_pcm *t_src_pcm, struct ba_transport_pcm *t_snk_pcm,
 		ba_transport_pcm_thread_func enc, ba_transport_pcm_thread_func dec,
@@ -724,6 +725,132 @@ static void test_io(
 
 	ba_transport_stop(t_snk);
 
+}
+
+/**
+ * Drive PCM signal through source/sink loop (multi client mix mode). */
+static void test_io_multi_mix(
+		struct ba_transport_pcm *t_src_pcm, struct ba_transport_pcm *t_snk_pcm,
+		ba_transport_pcm_thread_func enc, ba_transport_pcm_thread_func dec,
+		size_t pcm_write_frames_count) {
+
+	const char *enc_name = "encode";
+	const char *dec_name = "dump-bt";
+	struct ba_transport *t_src = t_src_pcm->t;
+	struct ba_transport *t_snk = t_snk_pcm->t;
+
+	if (input_bt_file != NULL)
+		return;
+
+	/* Reset the global termination flag before starting the loop. */
+	test_terminated = false;
+
+	int bt_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0, bt_fds), 0);
+	debug("Created BT socket pair: %d, %d", bt_fds[0], bt_fds[1]);
+
+	t_src->bt_fd = bt_fds[1];
+	t_snk->bt_fd = bt_fds[0];
+
+	int pcm_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, pcm_fds), 0);
+	debug("Created PCM socket pair: %d, %d", pcm_fds[0], pcm_fds[1]);
+	t_snk_pcm->fd = pcm_fds[0];
+
+	int ctl_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, ctl_fds), 0);
+
+	bt_data_init();
+
+	if (aging_duration)
+		test_start_terminate_timer(aging_duration);
+
+	ck_assert_ptr_nonnull(t_src_pcm->multi = ba_pcm_multi_create(t_src_pcm));
+	ck_assert_int_eq(ba_transport_pcm_start(t_src_pcm, enc, enc_name), 0);
+	ck_assert_int_eq(ba_transport_pcm_start(t_snk_pcm, dec, dec_name), 0);
+	ck_assert_int_eq(ba_pcm_multi_add_client(t_src_pcm->multi, pcm_fds[1], ctl_fds[1]), 1);
+	pcm_write_frames(t_snk_pcm, pcm_write_frames_count);
+
+	pthread_mutex_lock(&test_mutex);
+	while (!test_terminated)
+		pthread_cond_wait(&test_terminate, &test_mutex);
+	pthread_mutex_unlock(&test_mutex);
+
+	pthread_mutex_lock(&t_src_pcm->mutex);
+	ba_transport_pcm_release(t_src_pcm);
+	pthread_mutex_unlock(&t_src_pcm->mutex);
+
+	ba_transport_stop(t_src);
+
+	pthread_mutex_lock(&t_snk_pcm->mutex);
+	ba_transport_pcm_release(t_snk_pcm);
+	pthread_mutex_unlock(&t_snk_pcm->mutex);
+
+	ba_transport_stop(t_snk);
+	close(ctl_fds[0]);
+	close(ctl_fds[1]);
+}
+
+/**
+ * Drive PCM signal through source/sink loop (multi client snoop mode). */
+static void test_io_multi_snoop(
+		struct ba_transport_pcm *t_src_pcm, struct ba_transport_pcm *t_snk_pcm,
+		ba_transport_pcm_thread_func enc, ba_transport_pcm_thread_func dec) {
+
+	const char *enc_name = "dump-pcm";
+	const char *dec_name = "decode";
+	struct ba_transport *t_src = t_src_pcm->t;
+	struct ba_transport *t_snk = t_snk_pcm->t;
+
+	if (input_pcm_file != NULL)
+		return;
+
+	/* Reset the global termination flag before starting the loop. */
+	test_terminated = false;
+
+	int bt_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0, bt_fds), 0);
+	debug("Created BT socket pair: %d, %d", bt_fds[0], bt_fds[1]);
+	t_src->bt_fd = bt_fds[1];
+	t_snk->bt_fd = bt_fds[0];
+
+	int pcm_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, pcm_fds), 0);
+	debug("Created PCM socket pair: %d, %d", pcm_fds[0], pcm_fds[1]);
+	t_src_pcm->fd = pcm_fds[1];
+	t_snk_pcm->fd = pcm_fds[0];
+
+	int ctl_fds[2];
+	ck_assert_int_eq(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, ctl_fds), 0);
+
+	if (aging_duration)
+		test_start_terminate_timer(aging_duration);
+
+	ck_assert_ptr_nonnull(t_snk_pcm->multi = ba_pcm_multi_create(t_snk_pcm));
+	ck_assert_int_eq(ba_pcm_multi_init(t_snk_pcm->multi), 1);
+	ck_assert_int_eq(ba_pcm_multi_add_client(t_snk_pcm->multi, pcm_fds[0], ctl_fds[0]), 1);
+	ck_assert_int_eq(ba_transport_pcm_start(t_snk_pcm, dec, dec_name), 0);
+	ck_assert_int_eq(ba_transport_pcm_start(t_src_pcm, enc, enc_name), 0);
+	bt_data_write(t_src);
+
+	pthread_mutex_lock(&test_mutex);
+	while (!test_terminated)
+		pthread_cond_wait(&test_terminate, &test_mutex);
+	pthread_mutex_unlock(&test_mutex);
+
+	pthread_mutex_lock(&t_src_pcm->mutex);
+	ba_transport_pcm_release(t_src_pcm);
+	pthread_mutex_unlock(&t_src_pcm->mutex);
+
+	ba_transport_stop(t_src);
+
+	pthread_mutex_lock(&t_snk_pcm->mutex);
+	ba_transport_pcm_release(t_snk_pcm);
+	pthread_mutex_unlock(&t_snk_pcm->mutex);
+
+	ba_transport_stop(t_snk);
+	close(ctl_fds[0]);
+	close(ctl_fds[1]);
 }
 
 static int test_transport_acquire(struct ba_transport *t) {
@@ -1040,6 +1167,33 @@ CK_START_TEST(test_a2dp_sbc_pcm_drop) {
 
 } CK_END_TEST
 
+CK_START_TEST(test_a2dp_sbc_multi) {
+
+	struct ba_transport *t1 = test_transport_new_a2dp(device1,
+			BA_TRANSPORT_PROFILE_A2DP_SOURCE, "/path/sbc", &a2dp_sbc_source,
+			&config_sbc_44100_stereo);
+	struct ba_transport *t2 = test_transport_new_a2dp(device2,
+			BA_TRANSPORT_PROFILE_A2DP_SINK, "/path/sbc", &a2dp_sbc_sink,
+			&config_sbc_44100_stereo);
+
+	struct ba_transport_pcm *t1_pcm = &t1->media.pcm;
+	struct ba_transport_pcm *t2_pcm = &t2->media.pcm;
+
+	if (aging_duration) {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 153 * 3;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_sbc_enc_thread, a2dp_sbc_dec_thread, 4 * 1024);
+	}
+	else {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 153 * 3;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_sbc_enc_thread, test_io_thread_dump_bt, 4 * 1024);
+		test_io_multi_snoop(t1_pcm, t2_pcm, test_io_thread_dump_pcm, a2dp_sbc_dec_thread);
+	}
+
+	ba_transport_destroy(t1);
+	ba_transport_destroy(t2);
+
+} CK_END_TEST
+
 #if ENABLE_MP3LAME
 CK_START_TEST(test_a2dp_mp3) {
 
@@ -1206,6 +1360,33 @@ CK_START_TEST(test_a2dp_aptx_hd) {
 		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 60;
 		test_io(t1_pcm, t2_pcm, a2dp_aptx_hd_enc_thread, test_io_thread_dump_bt, 2 * 1024);
 		test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, a2dp_aptx_hd_dec_thread, 2 * 1024);
+	};
+
+	ba_transport_destroy(t1);
+	ba_transport_destroy(t2);
+
+} CK_END_TEST
+
+CK_START_TEST(test_a2dp_aptx_hd_multi) {
+
+	struct ba_transport *t1 = test_transport_new_a2dp(device1,
+			BA_TRANSPORT_PROFILE_A2DP_SOURCE, "/path/aptxhd", &a2dp_aptx_hd_source,
+			&config_aptx_hd_44100_stereo);
+	struct ba_transport *t2 = test_transport_new_a2dp(device2,
+			BA_TRANSPORT_PROFILE_A2DP_SINK, "/path/aptxhd", &a2dp_aptx_hd_sink,
+			&config_aptx_hd_44100_stereo);
+
+	struct ba_transport_pcm *t1_pcm = &t1->media.pcm;
+	struct ba_transport_pcm *t2_pcm = &t2->media.pcm;
+
+	if (aging_duration) {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 600;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_aptx_hd_enc_thread, a2dp_aptx_hd_dec_thread, 4 * 1024);
+	}
+	else {
+		t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 60;
+		test_io_multi_mix(t1_pcm, t2_pcm, a2dp_aptx_hd_enc_thread, test_io_thread_dump_bt, 4 * 1024);
+		test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, a2dp_aptx_hd_dec_thread, 4 * 1024);
 	};
 
 	ba_transport_destroy(t1);
@@ -1463,8 +1644,8 @@ CK_START_TEST(test_sco_msbc) {
 	struct ba_transport_pcm *t2_pcm = &t2->sco.pcm_spk;
 
 	t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 24;
-	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 600);
-	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 600);
+	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 2 * 600);
+	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 2 * 600);
 
 	ba_transport_destroy(t1);
 	ba_transport_destroy(t2);
@@ -1489,8 +1670,8 @@ CK_START_TEST(test_sco_lc3_swb) {
 	struct ba_transport_pcm *t2_pcm = &t2->sco.pcm_spk;
 
 	t1->mtu_read = t1->mtu_write = t2->mtu_read = t2->mtu_write = 24;
-	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 600);
-	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 600);
+	test_io(t1_pcm, t2_pcm, sco_enc_thread, test_io_thread_dump_bt, 2 * 600);
+	test_io(t1_pcm, t2_pcm, test_io_thread_dump_pcm, sco_dec_thread, 2 * 600);
 
 	ba_transport_destroy(t1);
 	ba_transport_destroy(t2);
@@ -1513,6 +1694,7 @@ int main(int argc, char *argv[]) {
 		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_pcm_drain },
 		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_pcm_drain_and_close },
 		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_pcm_drop },
+		{ a2dp_codec_to_string(A2DP_CODEC_SBC), test_a2dp_sbc_multi },
 #if ENABLE_MP3LAME
 		{ a2dp_codec_to_string(A2DP_CODEC_MPEG12), test_a2dp_mp3 },
 #endif
@@ -1525,6 +1707,7 @@ int main(int argc, char *argv[]) {
 #endif
 #if ENABLE_APTX_HD_IO_TEST
 		{ a2dp_codec_to_string(A2DP_CODEC_VENDOR_ID(APTX_HD_VENDOR_ID, APTX_HD_CODEC_ID)), test_a2dp_aptx_hd },
+		{ a2dp_codec_to_string(A2DP_CODEC_VENDOR_ID(APTX_HD_VENDOR_ID, APTX_HD_CODEC_ID)), test_a2dp_aptx_hd_multi },
 #endif
 #if ENABLE_FASTSTREAM
 		{ a2dp_codec_to_string(A2DP_CODEC_VENDOR_ID(FASTSTREAM_VENDOR_ID, FASTSTREAM_CODEC_ID)), test_a2dp_faststream_music },


### PR DESCRIPTION
Permit more than one client to open each PCM. For playback clients, the streams from each client are mixed together before encoding. For capture clients each client receives a copy of the decoded stream.

Stream mixing is done in C code, there is no explicit SIMD code. However, compiling with `-O3` does appear to allow `gcc` to optimize the mix loop very well on x86_64. I have not tested optimization with aarch64 (my old RPi machines are all 32-bit with no SIMD); but even without optimization I can run 3 playback clients simultaneously on a RPi zero W.

There was some interest in this feature three years ago, but there have been only a few enquiries more recently. I think this is pushing the scope boundary a little, as for most systems requiring multiple simultaneous audio applications there are also other requirements which mean that `pipewire` is probably a better fit. However I do have one genuine use case which is a "kiosk" system running only `chromium` which requires each chromium tab to independently open the PCM; and for this system BlueALSA with multi-client support is ideal. 
