### PR TITLE
ALSA PCM plugin: use transfer() callback

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -152,7 +152,7 @@ jobs:
             export LD_PRELOAD_SANITIZER="libasan.so.6" ;;
           *thread*)
             # As for now, not all tests pass with thread sanitizer enabled...
-            export XFAIL_TESTS="test-alsa-pcm test-utils-aplay"
+            export XFAIL_TESTS="test-utils-aplay"
             export LD_LIBRARY_PATH="${{ env.SANITIZE_THREAD_LIBS }}:$LD_LIBRARY_PATH"
             export LD_PRELOAD_SANITIZER="libtsan.so.0" ;;
         esac


### PR DESCRIPTION
As discussed in #745, using the ALSA PCM transfer() callback instead of allowing the ioplug to create and manage the ring buffer fixes the TSAN test failure.

Contrary to my supposition in #745, locking the pcm mutex within the transfer() function is not necessary, simply the fact that the bluealsa plugin now manages all access to the ring buffer means that thread synchronization is correct.