### PR TITLE
alsa plugins: do not install the config directly into $alsaconfdir

### DIFF
--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -1,5 +1,5 @@
 # BlueALSA - Makefile.am
-# Copyright (c) 2016-2023 Arkadiusz Bokowy
+# Copyright (c) 2016-2025 Arkadiusz Bokowy
 
 asound_module_ctl_LTLIBRARIES = libasound_module_ctl_bluealsa.la
 asound_module_pcm_LTLIBRARIES = libasound_module_pcm_bluealsa.la
@@ -21,7 +21,6 @@ libasound_module_pcm_bluealsa_la_SOURCES = \
 
 asound_module_ctldir = @ALSA_PLUGIN_DIR@
 asound_module_pcmdir = @ALSA_PLUGIN_DIR@
-asound_module_confdir = @ALSA_CONF_DIR@
 
 AM_CFLAGS = \
 	-I$(top_srcdir)/src \
@@ -46,3 +45,35 @@ MOSTLYCLEANFILES = $(asound_module_conf_DATA)
 
 .conf.in.conf:
 	$(SED) -e '' < $< > $@
+
+if ALSA_1_1_7
+# For ALSA >= 1.1.7 install the bluealsa config file into the $datadir tree and
+# create a symbolic link in the ALSA addon config directory.
+
+ALSA_DATADIR = alsa/alsa.conf.d
+asound_module_confdir = $(datadir)/$(ALSA_DATADIR)
+install-conf-hook:
+	$(MKDIR_P) $(DESTDIR)$(ALSA_CONF_DIR)
+	cd $(DESTDIR)$(ALSA_CONF_DIR) &&                \
+	    for i in $(asound_module_conf_DATA); do     \
+	        $(RM) $$i;                              \
+	        $(LN_S) $(asound_module_confdir)/$$i .; \
+	    done
+
+uninstall-conf-hook:
+	-cd $(DESTDIR)$(ALSA_CONF_DIR) &&           \
+	    for i in $(asound_module_conf_DATA); do \
+	        $(RM) $$i;                          \
+	    done
+	-cd $(DESTDIR)$(datadir) && \
+	    rmdir -p $(ALSA_DATADIR)
+
+install-data-hook: install-conf-hook
+uninstall-local: uninstall-conf-hook
+
+else
+# For ALSA < 1.1.7 install the bluealsa config file into the ALSA addon config
+# directory.
+
+asound_module_confdir = @ALSA_CONF_DIR@
+endif


### PR DESCRIPTION
This PR returns to a discussion raised 4 years ago: #470, implementing the change originally suggested there.

The installation of the BlueALSA ALSA plugins config file becomes consistent with both the alsa-plugins project and pipewire. Although pipewire does not itself create the symbolic links, (that is left up to distribution package installers) I think that BlueALSA should follow the example of alsa-plugins as that should cause fewer surprises for our users.