### PR TITLE
A set of commits aimed at reducing the occurences of CI test failures.

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -152,7 +152,6 @@ jobs:
             export LD_PRELOAD_SANITIZER="libasan.so.6" ;;
           *thread*)
             # As for now, not all tests pass with thread sanitizer enabled...
-            export XFAIL_TESTS="test-utils-aplay"
             export LD_LIBRARY_PATH="${{ env.SANITIZE_THREAD_LIBS }}:$LD_LIBRARY_PATH"
             export LD_PRELOAD_SANITIZER="libtsan.so.0" ;;
         esac

--- a/src/ba-transport.c
+++ b/src/ba-transport.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - ba-transport.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -196,10 +196,18 @@ static void *transport_thread_manager(struct ba_transport *t) {
 			switch (cmd) {
 			case BA_TRANSPORT_THREAD_MANAGER_TERMINATE:
 				goto exit;
-			case BA_TRANSPORT_THREAD_MANAGER_CANCEL_THREADS:
-				transport_threads_cancel(t);
-				timeout = -1;
+			case BA_TRANSPORT_THREAD_MANAGER_CANCEL_THREADS: {
+				/* No not cancel the threads again if they are already stopped */
+				bool stopping;
+				pthread_mutex_lock(&t->bt_fd_mtx);
+				stopping = t->stopping;
+				pthread_mutex_unlock(&t->bt_fd_mtx);
+				if (stopping) {
+					transport_threads_cancel(t);
+					timeout = -1;
+				}
 				break;
+			}
 			case BA_TRANSPORT_THREAD_MANAGER_CANCEL_IF_NO_CLIENTS:
 				debug("PCM clients check keep-alive: %d ms", config.keep_alive_time);
 				timeout = config.keep_alive_time;

--- a/src/bluealsa-dbus.c
+++ b/src/bluealsa-dbus.c
@@ -1,6 +1,6 @@
 /*
  * BlueALSA - bluealsa-dbus.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -462,9 +462,6 @@ static gboolean bluealsa_pcm_controller(GIOChannel *ch, GIOCondition condition,
 		ba_transport_pcm_release(pcm);
 		pthread_mutex_unlock(&pcm->mutex);
 		ba_transport_pcm_signal_send(pcm, BA_TRANSPORT_PCM_SIGNAL_CLOSE);
-		/* Check whether we've just closed the last PCM client and in
-		 * such a case schedule transport IO threads termination. */
-		ba_transport_stop_if_no_clients(pcm->t);
 		/* remove channel from watch */
 		return FALSE;
 	}

--- a/test/test-alsa-midi.c
+++ b/test/test-alsa-midi.c
@@ -1,6 +1,6 @@
 /*
  * test-alsa-midi.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -178,7 +178,7 @@ int main(int argc, char *argv[]) {
 
 	tcase_add_test(tc, test_port);
 	tcase_add_test(tc, test_sequencer);
-
+	tcase_set_timeout(tc, 7);
 	srunner_run_all(sr, CK_ENV);
 	int nf = srunner_ntests_failed(sr);
 

--- a/test/test-alsa-pcm.c
+++ b/test/test-alsa-pcm.c
@@ -1,6 +1,6 @@
 /*
  * test-alsa-pcm.c
- * Copyright (c) 2016-2024 Arkadiusz Bokowy
+ * Copyright (c) 2016-2025 Arkadiusz Bokowy
  *
  * This file is a part of bluez-alsa.
  *
@@ -924,7 +924,7 @@ CK_START_TEST(test_playback_pause) {
 		ck_assert_int_eq(snd_pcm_state_runtime(pcm), SND_PCM_STATE_RUNNING);
 
 		/* wait a little bit */
-		usleep(3 * period_time / 2);
+		usleep(2 * period_time);
 
 		/* check resume: more available frames, lower delay */
 		ck_assert_int_gt(snd_pcm_avail(pcm), frames);

--- a/test/test-rfcomm.c
+++ b/test/test-rfcomm.c
@@ -186,6 +186,7 @@ CK_START_TEST(test_rfcomm_hsp_hs) {
 #if ENABLE_HFP_CODEC_SELECTION
 static void *test_rfcomm_hfp_ag_switch_codecs(void *userdata) {
 	struct ba_transport *sco = userdata;
+	usleep(5000);
 	pthread_mutex_lock(&sco->codec_select_client_mtx);
 	ck_assert_int_eq(ba_transport_select_codec_sco(sco, HFP_CODEC_CVSD), 0);
 	/* The test code rejects first codec selection request for mSBC. */


### PR DESCRIPTION
 There are still some occasional failures remaining, but overall the failure rate is greatly improved.

Tests with known races that can still cause failure:
- test-alsa-pcm:test_playback_hw_set_free
- test-utils-aplay:test_play_dbus_signals
- test-rfcomm

Tests that may still occasionally fail for unknown reasons:
- test-dbus
- test-alsa-midi