### PR TITLE
test: fix mock dependency makefile rule

### DIFF
--- a/test/mock/Makefile.am
+++ b/test/mock/Makefile.am
@@ -33,7 +33,7 @@ bluealsad_mock_LDADD = \
 	@GIO2_LIBS@ \
 	@GLIB2_LIBS@
 
-.xml.h:
+dbus-ifaces.h: dbus-ifaces.xml
 	gdbus-codegen --output $@ \
 		--interface-prefix org \
 		--c-namespace Mock \


### PR DESCRIPTION
The auto-generated dependencies for the test mock server include a dependency on bluealsa-iface.h (correctly) as a relative path, for example build/test/mock/.deps/bluealsad_mock_mock.Po has:

	bluealsad_mock-mock.o:
		../../../src/bluealsa-iface.h

The mock makefile has a rule to build all *.h from *.xml using gdbus-codegen. These two things combined result in the git controlled file src/bluealsa-iface.h being overwritten by dbus-codegen whenever src/bluealsa-iface.xml is more recent than src/bluealsa-iface.h. This can cause build failure.

This fix replaces the generic "build all .h with .xml dependency" rule with a specific rule just for the one header file which really does need to be built.