### PR TITLE
Avoid NULL pointer deref when libsandbox is in LD_PRELOAD

### DIFF
--- a/test/libaloader.c
+++ b/test/libaloader.c
@@ -67,6 +67,9 @@ void *dlopen(const char *filename, int flags) {
 	if (strstr(filename, "libasound_module_pcm_bluealsa.so") != NULL)
 		filename = strcat(tmp, "/src/asound/.libs/libasound_module_pcm_bluealsa.so");
 
+	if (dlopen_orig == NULL)
+		dlopen_orig = dlsym(RTLD_NEXT, "dlopen");
+
 	return dlopen_orig(filename, flags);
 }
 


### PR DESCRIPTION
libsandbox[1] calls dlopen() inside a constructor function. If this constructor happens to run before the init() function in libaloader.c, dlopen_orig will still be NULL and the program will crash with a segfault.

Avoid this by calling dlsym() inside the dlopen() wrapper itself when necessary.

[1] https://github.com/gentoo/sandbox

Bug: https://bugs.gentoo.org/973030