### PR TITLE
aplay: fix ALSA mixer event handler

### DIFF
--- a/utils/aplay/alsa-mixer.c
+++ b/utils/aplay/alsa-mixer.c
@@ -16,7 +16,7 @@
 
 static int alsa_mixer_elem_callback(snd_mixer_elem_t *elem, unsigned int mask) {
 	struct alsa_mixer *mixer = snd_mixer_elem_get_callback_private(elem);
-	if (mask & SND_CTL_EVENT_MASK_REMOVE)
+	if (mask == SND_CTL_EVENT_MASK_REMOVE)
 		/* The element has been removed and cannot
 		 * now be used - we must close the mixer. */
 		 return -1;


### PR DESCRIPTION
Fix bug in ALSA event handling whereby all events were treated as if they were element removed events, so that volume changes made by other applications (such as alsamixer) were not reported back to the bluetooth device.

This is a one-liner that hopefully can be squeezed into release 5.0.0 ?